### PR TITLE
Add link readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Welcome to Explorer!
 
 *tl;dr sandiego-rh/explorer organizes the visualizations and data generated in the sandiego-rh/sandiego repo as a web-app.*
 
+[Example of Application](https://sandiego-explorer.osci.io/overview)
+
 The number of repositories and projects that GitHub hosts is staggering. Even more impressive is the rate at which this number is growing.
 Projects on GitHub range some student projects that are likely to only be updated a handful of times ever to technological monoliths like the
 Linux Kernel. Understanding the growth trajectory, contributor behavior, progress blockers, etc. intuitively is no longer feasible for individual


### PR DESCRIPTION
Adds a link to our openshift deployment to our README so that people can see the current state of our project without having to download and run our codebase.