### PR TITLE
check for config.json and production environment

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,15 +9,24 @@ from dash_bootstrap_templates import load_figure_template
 
 from db_interface.AugurInterface import AugurInterface
 import os
+import sys
 
 # Get config details
 try:
     assert os.environ["running_on"] == "prod"
     augur_db = AugurInterface()
 except KeyError:
-    augur_db = AugurInterface("./config.json")
+    # check that config file is available
+    if os.path.exists("config.json"):
+        augur_db = AugurInterface("./config.json")
+    else:
+        print("No 'config.json' available at top level. Config required by name.")
+        sys.exit(1)
 
 engine = augur_db.get_engine()
+if engine is None:
+    print("Could not get engine; check config or try later")
+    sys.exit(1)
 
 
 # load styling and start app

--- a/index.py
+++ b/index.py
@@ -170,7 +170,19 @@ print("VALIDATE_LAYOUT - END")
 
 
 def main():
-    app.run_server(host="0.0.0.0", port=8050, debug=True)
+
+    # shouldn't run server in debug mode if we're in a production setting
+
+    debug_mode = True
+    try:
+        if os.environ["running_on"] == "prod":
+            debug_mode = False
+        else:
+            debug_mode = True
+    except:
+        debug_mode = True
+
+    app.run_server(host="0.0.0.0", port=8050, debug=debug_mode)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Added two required features:

(1) if no config file is available in the directory, app exits gracefully and prints error

(2) app won't run with debug=True if the environment variable "running_on"="prod"; stops live reloading overhead

Signed-off-by: JamesKunstle <jkunstle@bu.edu>