### PR TITLE
Removes auto build/push w.r.t main branch

### DIFF
--- a/.github/workflows/build-push-quay.yml
+++ b/.github/workflows/build-push-quay.yml
@@ -2,7 +2,6 @@ name: Build and Push Image
 on:
     push:
         branches:
-            - main
             - dev
 
 jobs:


### PR DESCRIPTION
Whenever we pushed code from dev to main we would
repeat the build of the same extant container and push it to
Quay. This change removes pushing to main as a trigger.

Signed-off-by: JamesKunstle <jkunstle@bu.edu>