### PR TITLE
Fixes search bar clobbering

### DIFF
--- a/app.py
+++ b/app.py
@@ -155,8 +155,6 @@ app.layout = dbc.Container(
                                             is_open=False,
                                             color="info",
                                         ),
-                                    ]
-                                        )
                                     ],
                                     style={
                                         "width": "50%",

--- a/app.py
+++ b/app.py
@@ -141,8 +141,8 @@ app.layout = dbc.Container(
                                         dcc.Dropdown(
                                             id="projects",
                                             multi=True,
-                                            value=[search_input],
                                             options=[search_input],
+                                            value=[search_input],
                                         ),
                                         dbc.Alert(
                                             children='Please ensure that your spelling is correct. \
@@ -155,6 +155,8 @@ app.layout = dbc.Container(
                                             is_open=False,
                                             color="info",
                                         ),
+                                    ]
+                                        )
                                     ],
                                     style={
                                         "width": "50%",

--- a/app_callbacks.py
+++ b/app_callbacks.py
@@ -80,7 +80,7 @@ def _parse_org_choices(org_name_set):
     [Input("projects", "search_value")],
     [State("projects", "value")],
 )
-def dropdown_dynamic_callback(search, bar_state):
+def dropdown_dynamic_callback(user_in, selections):
 
     """
     Ref: https://dash.plotly.com/dash-core-components/dropdown#dynamic-options
@@ -91,22 +91,25 @@ def dropdown_dynamic_callback(search, bar_state):
     either of the options.
     """
 
-    if search is None or len(search) == 0:
+    if selections is None:
+        selections = []
+
+    if user_in is None or len(user_in) == 0:
         raise dash.exceptions.PreventUpdate
     else:
-        if bar_state is not None:
-            opts = [i[1] for i in all_entries if search.lower() in i[0] or i[1] in bar_state]
-            # opts = [i for i in entries if search in i or i in bar_state]
-        else:
-            opts = [i for i in entries if search in i]
+        # match lowercase inputs with lowercase possible values
+        opts = [i[1] for i in all_entries if user_in.lower() in i[0]]
 
+        # sort matches by length
         opts.sort(key=lambda item: (len(item), item))
 
+        # always include the previous selections from the searchbar to avoid
+        # those values being clobbered when we truncate the total length.
         # arbitrarily 'small' number of matches returned..
         if len(opts) < 250:
-            return [opts]
+            return [opts + selections]
         else:
-            return [opts[:250]]
+            return [opts[:250] + selections]
 
 
 # call back for repo selctions to feed into visualization call backs


### PR DESCRIPTION
     A value selected in the search bar must also be in the options
    list, otherwise it's removed.
    
    This was introducing a bug because longer repo addresses were
    being dropped but org addresses weren't.
    
    This was because for short inputs of only a few letters, the addresses
    of repos were of index >250 so they were dropped when we limited
    the length of the returnable options, which had the side-effect of removing
    them from the list.
    
    This change ensures that those values currently selected are always appended
    to the end of the options list so they won't be removed randomly.

Fixes #71 