### PR TITLE
Adds notice for search-bar help

### DIFF
--- a/app.py
+++ b/app.py
@@ -139,7 +139,18 @@ app.layout = dbc.Container(
                                             multi=True,
                                             value=[search_input],
                                             options=[search_input],
-                                        )
+                                        ),
+                                        dbc.Alert(
+                                            children='Please ensure that your spelling is correct. \
+                                                If your selection definitely isn\'t present, please request that \
+                                                it be loaded using the help button "REPO/ORG Request" \
+                                                in the bottom right corner of the screen.',
+                                            id="help-alert",
+                                            dismissable=True,
+                                            fade=True,
+                                            is_open=False,
+                                            color="info",
+                                        ),
                                     ],
                                     style={
                                         "width": "50%",
@@ -153,6 +164,16 @@ app.layout = dbc.Container(
                                     id="search",
                                     n_clicks=0,
                                     class_name="btn btn-primary",
+                                    style={
+                                        "verticalAlign": "top",
+                                        "display": "table-cell",
+                                    },
+                                ),
+                                dbc.Button(
+                                    "Help",
+                                    id="search-help",
+                                    n_clicks=0,
+                                    class_name="btn btn-light",
                                     style={
                                         "verticalAlign": "top",
                                         "display": "table-cell",

--- a/app_callbacks.py
+++ b/app_callbacks.py
@@ -253,3 +253,12 @@ def generate_issues_data(repo_ids):
     logging.debug("ISSUES_DATA_QUERY - END")
 
     return df_issues.to_dict("records")
+
+
+@callback(Output("help-alert", "is_open"), Input("search-help", "n_clicks"), State("help-alert", "is_open"))
+def show_help_alert(n_clicks, openness):
+    if n_clicks == 0:
+        return dash.no_update
+    # switch the openness parameter, allows button to also
+    # dismiss the Alert.
+    return not openness


### PR DESCRIPTION
This change provides the user with a note that if they can't see their
selection in the search bar, they need to first check their spelling,
and otherwise to request that the selection be loaded in manually.

Signed-off-by: JamesKunstle <jkunstle@bu.edu>