### PR TITLE
add development dockerfiles + script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,4 @@ output_time.txt
 output.dat
 env.sh
 dump.rdb
+env.list

--- a/Dockerfile.supervisor_workers
+++ b/Dockerfile.supervisor_workers
@@ -9,6 +9,12 @@ EXPOSE 8050
 # install pipenv
 RUN pip install pipenv
 
+# install supervisor
+RUN pip install supervisor 
+
+# copy config
+ADD supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+
 # create a working directory
 RUN mkdir explorer
 
@@ -22,9 +28,12 @@ COPY ./ /explorer/
 # install required modules at system level
 RUN pipenv install --system --deploy
 
+# run supervisord
+CMD supervisord
+
 # run app
 # Description of how to choose the number of workers and threads.
 # common wisdom is (2*CPU)+1 workers: 
 # https://medium.com/building-the-system/gunicorn-3-means-of-concurrency-efbb547674b7
-CMD gunicorn --bind :8050 app:server --workers 4 --threads 4
+# CMD gunicorn --bind :8050 app:server --workers 4 --threads 4
 

--- a/scripts/launch_dev.sh
+++ b/scripts/launch_dev.sh
@@ -1,0 +1,58 @@
+# can pass target port number to script for redis as: bash ./this_script.sh <new_port>
+# TODO redis doesn't currently like this and I'm not sure why
+if [ -z "$1" ]
+    then
+        echo "No Redis remap-port supplied."
+        echo "Defaulting to port: 6379"
+        printf "\n"
+        REDIS_PORT_MAP=6379;
+    else
+        echo "Redis remap-port supplied.";
+        echo "Mapping container port 6379 to: $1";
+        printf "\n";
+        REDIS_PORT_MAP=$1;
+fi
+
+
+# create network for containers 
+docker network create eightknot-network ;
+
+# create a redis instance inside of a container, on our docker network, mapped to its respective port. 
+sudo docker run --rm -itd --name redis --net eightknot-network -p $REDIS_PORT_MAP:6379 redis;
+
+# grab the route to the redis server from the running redis container
+REDIS_CONTAINER_URL=$(docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' redis);
+printf "\nRedis URL is: ${REDIS_CONTAINER_URL}:${REDIS_PORT_MAP}\n";
+
+# build and run the worker pool
+sudo docker build -f Dockerfile.supervisor_workers -t worker_pool .;
+docker run --rm -dit --name worker_pool \
+                     --net eightknot-network \
+                     --env REDIS_SERVICE_HOST=$REDIS_CONTAINER_URL \
+                     --env REDIS_SERVICE_PORT=$REDIS_PORT_MAP \
+                     worker_pool;
+
+# build and run the web server
+sudo docker build -f Dockerfile.server -t eightknot_server .;
+sudo docker run --rm -it --name eightknot_server \
+                         --net eightknot-network \
+                         --env REDIS_SERVICE_HOST=$REDIS_CONTAINER_URL \
+                         --env REDIS_SERVICE_PORT=$REDIS_PORT_MAP \
+                         --env-file ./env.list \
+                         -p 8050:8050 \
+                         eightknot_server;
+
+# cleanup
+printf "\nShutting down worker pool...\n"
+sudo docker stop worker_pool;
+
+printf "\nShutting down redis...\n"
+sudo docker stop redis;
+
+printf "\nRemaining containers:\n"
+docker ps -a;
+
+printf "\nDeleting network...\n"
+docker network rm eightknot-network;
+
+printf "\nCleanup Done :) \n"

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,0 +1,13 @@
+[supervisord]
+nodaemon=true
+
+[program:worker]
+numprocs=8
+command=rq worker -c worker_settings
+process_name=%(program_name)s_%(process_num)02d
+autostart=true
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0


### PR DESCRIPTION
updates development dockerfile to launch:

redis, job_queue workers, and web server

from a single script. requires only that user
supplies env.list, which is a key-value pairing of the environment variables usually set in production.

update required because it's a hassle for users to source their environment variables and to spin up however-many required worker processes manually.

Signed-off-by: James Kunstle <jkunstle@bu.edu>