### PR TITLE
Add missing words to spellcheck wordlist

### DIFF
--- a/.wordlist-md
+++ b/.wordlist-md
@@ -90,3 +90,8 @@ backend
 href's
 TLS
 OAuth's
+wg
+macOS
+podman
+ctrl
+ps


### PR DESCRIPTION
This fixes the check on the pre-commit spellcheck issue on the search bar PR #777 