### PR TITLE
fix forgotten conversion from str to int

### DIFF
--- a/8Knot/pages/index/index_callbacks.py
+++ b/8Knot/pages/index/index_callbacks.py
@@ -437,6 +437,8 @@ def multiselect_values_to_repo_ids(n_clicks, user_vals):
         logging.warning("NOTHING SELECTED IN SEARCH BAR")
         raise dash.exceptions.PreventUpdate
 
+    user_vals = [int(n) if n.isnumeric() else n for n in user_vals]
+
     # individual repo numbers
     repos = [r for r in user_vals if isinstance(r, int)]
     logging.warning(f"REPOS: {repos}")


### PR DESCRIPTION
I was noticing issues with the two callbacks (for scorecard and repo general info) as a result of my changes in #935 (because mantine forced the selection values to be strings and I missed places where this is assumed/relied upon).

Seems like some contributing factors to this included:
- lack of defined types in python function signatures/in general
- me trying to get the mantine fix in before the welcome page
- me not understanding the full complexity of dash and how al of our callbacks interact to do things


I cant promise this is the last one of these that I find - If someone has docs or something that documents the path that the selected repo data takes from either of the two search/selection bars (main and repo-overview), that would help with auditing to make sure the codepath is correctly migrated to accomodate this new mantine requirement for string values