### PR TITLE
update width for date range picker so both halves show on one line

### DIFF
--- a/8Knot/pages/affiliation/visualizations/commit_domains.py
+++ b/8Knot/pages/affiliation/visualizations/commit_domains.py
@@ -99,7 +99,7 @@ gc_commit_domains = dbc.Card(
                                         clearable=True,
                                         className="dark-date-picker",
                                     ),
-                                    width=5,
+                                    width=7,
                                 ),
                             ],
                             align="center",

--- a/8Knot/pages/affiliation/visualizations/gh_org_affiliation.py
+++ b/8Knot/pages/affiliation/visualizations/gh_org_affiliation.py
@@ -99,7 +99,7 @@ gc_gh_org_affiliation = dbc.Card(
                                         clearable=True,
                                         className="dark-date-picker",
                                     ),
-                                    width=5,
+                                    width=7,
                                 ),
                             ],
                             align="center",

--- a/8Knot/pages/affiliation/visualizations/org_associated_activity.py
+++ b/8Knot/pages/affiliation/visualizations/org_associated_activity.py
@@ -133,7 +133,7 @@ gc_org_associated_activity = dbc.Card(
                                         clearable=True,
                                         className="dark-date-picker",
                                     ),
-                                    width=5,
+                                    width=7,
                                 ),
                             ],
                             justify="start",

--- a/8Knot/pages/affiliation/visualizations/org_core_contributors.py
+++ b/8Knot/pages/affiliation/visualizations/org_core_contributors.py
@@ -126,7 +126,7 @@ gc_org_core_contributors = dbc.Card(
                                         className="dark-date-picker",
                                     ),
                                     # style={"marginTop": "1.7rem"},
-                                    width=5,
+                                    width=7,
                                 ),
                                 dbc.Col(
                                     dbc.Checklist(

--- a/8Knot/pages/affiliation/visualizations/unqiue_domains.py
+++ b/8Knot/pages/affiliation/visualizations/unqiue_domains.py
@@ -98,7 +98,7 @@ gc_unique_domains = dbc.Card(
                                         clearable=True,
                                         className="dark-date-picker",
                                     ),
-                                    width=5,
+                                    width=7,
                                 ),
                             ],
                             align="center",

--- a/8Knot/pages/chaoss/visualizations/contrib_importance_pie.py
+++ b/8Knot/pages/chaoss/visualizations/contrib_importance_pie.py
@@ -151,7 +151,7 @@ gc_contrib_importance_pie = dbc.Card(
                                         clearable=True,
                                         className="dark-date-picker",
                                     ),
-                                    width=5,
+                                    width=7,
                                 ),
                             ],
                             align="center",

--- a/8Knot/pages/chaoss/visualizations/project_velocity.py
+++ b/8Knot/pages/chaoss/visualizations/project_velocity.py
@@ -215,7 +215,7 @@ gc_project_velocity = dbc.Card(
                                         clearable=True,
                                         className="dark-date-picker",
                                     ),
-                                    width=5,
+                                    width=7,
                                 ),
                             ],
                         ),

--- a/8Knot/pages/contributions/visualizations/cntrb_pr_assignment.py
+++ b/8Knot/pages/contributions/visualizations/cntrb_pr_assignment.py
@@ -139,7 +139,7 @@ gc_cntrib_pr_assignment = dbc.Card(
                                         clearable=True,
                                         className="dark-date-picker",
                                     ),
-                                    width=5,
+                                    width=7,
                                 ),
                             ],
                             align="center",

--- a/8Knot/pages/contributions/visualizations/cntrib_issue_assignment.py
+++ b/8Knot/pages/contributions/visualizations/cntrib_issue_assignment.py
@@ -146,7 +146,7 @@ gc_cntrib_issue_assignment = dbc.Card(
                                         clearable=True,
                                         className="dark-date-picker",
                                     ),
-                                    width=5,
+                                    width=7,
                                 ),
                             ],
                             align="center",

--- a/8Knot/pages/contributions/visualizations/issues_over_time.py
+++ b/8Knot/pages/contributions/visualizations/issues_over_time.py
@@ -100,18 +100,21 @@ gc_issues_over_time = dbc.Card(
                             justify="start",
                         ),
                         dbc.Row(
-                            dcc.DatePickerRange(
-                                id=f"date-picker-range-{PAGE}-{VIZ_ID}",
-                                min_date_allowed=dt.date(2005, 1, 1),
-                                max_date_allowed=dt.date.today(),
-                                initial_visible_month=dt.date(dt.date.today().year, 1, 1),
-                                clearable=True,
-                                start_date=dt.date(
-                                    dt.date.today().year - 2,
-                                    dt.date.today().month,
-                                    dt.date.today().day,
+                            dbc.Col(
+                                dcc.DatePickerRange(
+                                    id=f"date-picker-range-{PAGE}-{VIZ_ID}",
+                                    min_date_allowed=dt.date(2005, 1, 1),
+                                    max_date_allowed=dt.date.today(),
+                                    initial_visible_month=dt.date(dt.date.today().year, 1, 1),
+                                    clearable=True,
+                                    start_date=dt.date(
+                                        dt.date.today().year - 2,
+                                        dt.date.today().month,
+                                        dt.date.today().day,
+                                    ),
+                                    className="dark-date-picker",
                                 ),
-                                className="dark-date-picker",
+                                width=7,
                             ),
                         ),
                     ]

--- a/8Knot/pages/contributors/visualizations/contrib_importance_pie.py
+++ b/8Knot/pages/contributors/visualizations/contrib_importance_pie.py
@@ -147,19 +147,22 @@ gc_contrib_importance_pie = dbc.Card(
                             justify="start",
                         ),
                         dbc.Row(
-                            dcc.DatePickerRange(
-                                id=f"date-picker-range-{PAGE}-{VIZ_ID}",
-                                min_date_allowed=dt.date(2005, 1, 1),
-                                max_date_allowed=dt.date.today(),
-                                initial_visible_month=dt.date(dt.date.today().year, 1, 1),
-                                clearable=True,
-                                start_date=dt.date(
-                                    dt.date.today().year - 2,
-                                    dt.date.today().month,
-                                    dt.date.today().day,
+                            dbc.Col(
+                                dcc.DatePickerRange(
+                                    id=f"date-picker-range-{PAGE}-{VIZ_ID}",
+                                    min_date_allowed=dt.date(2005, 1, 1),
+                                    max_date_allowed=dt.date.today(),
+                                    initial_visible_month=dt.date(dt.date.today().year, 1, 1),
+                                    clearable=True,
+                                    start_date=dt.date(
+                                        dt.date.today().year - 2,
+                                        dt.date.today().month,
+                                        dt.date.today().day,
+                                    ),
+                                    className="dark-date-picker",
                                 ),
-                                className="dark-date-picker",
-                            ),
+                                width=7,
+                            )
                         ),
                     ]
                 ),


### PR DESCRIPTION
This bumps the width of the date picker (which seems to always be in a row by itself) from 5 columns to 7 (and adds a `dbc.Col` wrapper where necessary to accomplish this). This allows both ends of the date range to be side-by-side.

related to #915

