### PR TITLE
Refactor visualizations - trial PR

### DIFF
--- a/8Knot/components/visualization.py
+++ b/8Knot/components/visualization.py
@@ -1,0 +1,102 @@
+from dash import html, dcc, Input, State, Output, callback, MATCH
+import dash_bootstrap_components as dbc
+
+
+# All-in-One Components should be suffixed with 'AIO'
+class VisualizationAIO(dbc.Card):
+    def __init__(
+        self,
+        page: str,
+        viz_id: str,
+        graph_info="",
+        class_name="",
+        controls=None,
+        title: str = "",
+        id: Optional[str] = None,
+    ):
+        """
+        Common visualization shell to be shared by all visualizations
+
+        Args:
+            page (str): The name of the page this visualization is part of
+            viz_id (str): a unique id for this visualization
+            graph_info (str): The description of this graph giving more information on what it describes and where its data came from. Displayed in a popover.
+            class_name (str): Any custom class names to associate with this card
+            controls (list): A list of form elements to display within the lower form Row at the bottom of the graph
+            title (Optional[str]): a static title. If none, the title will be fetched from a callback with the id "graph-title-{page}-{viz_id}". Defaults to none.
+            id (Optional[str]): an identifier to use to jump to the card. Primarily intended for navigation, not for styling. Defaults to none, which causes {page}-{viz_id} to be used
+        """
+        self.page = page
+        self.viz_id = viz_id
+        self.nav_id = id
+
+        if controls is None:
+            controls = []
+
+        # Define the component's layout
+        super().__init__(
+            [
+                dbc.CardBody(
+                    [
+                        dbc.Row(
+                            [
+                                dbc.Col(html.H3(title, id=f"graph-title-{page}-{viz_id}", className="card-title")),
+                                dbc.Col(
+                                    dbc.Button(
+                                        "About Graph",
+                                        id={"type": "popover-target", "index": f"{page}-{viz_id}"},
+                                        color="outline-secondary",
+                                        size="sm",
+                                        className="about-graph-button",
+                                    ),
+                                    width="auto",
+                                ),
+                            ],
+                            align="center",
+                            justify="between",
+                            className="mb-3",
+                        ),
+                        dbc.Popover(
+                            [
+                                dbc.PopoverHeader("Graph Info:"),
+                                dbc.PopoverBody(graph_info),
+                            ],
+                            id={"type": "popover", "index": f"{page}-{viz_id}"},
+                            target={"type": "popover-target", "index": f"{page}-{viz_id}"},
+                            placement="top",
+                            is_open=False,
+                        ),
+                        dcc.Loading(
+                            dcc.Graph(id=f"{page}-{viz_id}"),
+                            style={"marginBottom": "1rem"},
+                        ),
+                        html.Hr(className="card-split") if controls else None,  # Divider between graph and controls
+                        dbc.Form(
+                            [
+                                dbc.Row(
+                                    controls,
+                                    align="center",
+                                    justify="start",
+                                ),
+                            ]
+                        )
+                        if controls
+                        else None,
+                    ],
+                    style={"padding": "1.5rem"},
+                ),
+            ],
+            className=class_name,
+            id=(self.nav_id if self.nav_id is not None else f"{self.page}-{self.viz_id}"),
+        )
+
+    # callback for graph info popover
+    @callback(
+        Output({"type": "popover", "index": MATCH}, "is_open"),
+        [Input({"type": "popover-target", "index": MATCH}, "n_clicks")],
+        [State({"type": "popover", "index": MATCH}, "is_open")],
+    )
+    def toggle_popover(n, is_open):
+        if n:
+            return not is_open
+        return is_open

--- a/8Knot/components/visualization.py
+++ b/8Knot/components/visualization.py
@@ -1,6 +1,6 @@
 from dash import html, dcc, Input, State, Output, callback, MATCH
 import dash_bootstrap_components as dbc
-
+from typing import Optional
 
 # All-in-One Components should be suffixed with 'AIO'
 class VisualizationAIO(dbc.Card):

--- a/8Knot/pages/chaoss/visualizations/contrib_importance_pie.py
+++ b/8Knot/pages/chaoss/visualizations/contrib_importance_pie.py
@@ -17,167 +17,109 @@ import datetime as dt
 import app
 import pages.utils.preprocessing_utils as preproc_utils
 import cache_manager.cache_facade as cf
+from components.visualization import VisualizationAIO
 
 PAGE = "chaoss"
 VIZ_ID = "contrib-importance-pie"
 
-gc_contrib_importance_pie = dbc.Card(
-    [
-        dbc.CardBody(
-            [
-                dbc.Row(
-                    [
-                        dbc.Col(html.H3(id=f"graph-title-{PAGE}-{VIZ_ID}", className="card-title")),
-                        dbc.Col(
-                            dbc.Button(
-                                "About Graph",
-                                id=f"popover-target-{PAGE}-{VIZ_ID}",
-                                color="outline-secondary",
-                                size="sm",
-                                className="about-graph-button",
-                            ),
-                            width="auto",
-                        ),
-                    ],
-                    align="center",
-                    justify="between",
-                    className="mb-3",
-                ),
-                dbc.Popover(
-                    [
-                        dbc.PopoverHeader("Graph Info:"),
-                        dbc.PopoverBody(
-                            """
-                                        AKA Bus factor. For a given action type, this visualizes the proportional share of the top k anonymous
-                                        contributors, aggregating the remaining contributors as "Other". Suppose Contributor A
-                                        opens the most PRs of all contributors, accounting for 1/5 of all PRs. If k = 1,
-                                        then the chart will have one slice for Contributor A accounting for 1/5 of the area,
-                                        with the remaining 4/5 representing all other contributors. Note: Some commits may have a
-                                        Contributor ID of 'None' if there is no GitHub account is associated with the email that
-                                        the contributor committed as.
-                                        """
-                        ),
-                    ],
-                    id=f"popover-{PAGE}-{VIZ_ID}",
-                    target=f"popover-target-{PAGE}-{VIZ_ID}",
-                    placement="top",
-                    is_open=False,
-                ),
-                dcc.Loading(
-                    dcc.Graph(id=f"{PAGE}-{VIZ_ID}"),
-                    style={"marginBottom": "1rem"},
-                ),
-                html.Hr(className="card-split"),  # Divider between graph and controls
-                dbc.Form(
-                    [
-                        dbc.Row(
-                            [
-                                dbc.Label(
-                                    "Action Type:",
-                                    html_for=f"action-type-{PAGE}-{VIZ_ID}",
-                                    width={"size": "auto"},
-                                ),
-                                dbc.Col(
-                                    dcc.Dropdown(
-                                        id=f"action-type-{PAGE}-{VIZ_ID}",
-                                        options=[
-                                            {"label": "Commit", "value": "Commit"},
-                                            {
-                                                "label": "Issue Opened",
-                                                "value": "Issue Opened",
-                                            },
-                                            {
-                                                "label": "Issue Comment",
-                                                "value": "Issue Comment",
-                                            },
-                                            {
-                                                "label": "Issue Closed",
-                                                "value": "Issue Closed",
-                                            },
-                                            {
-                                                "label": "PR Open",
-                                                "value": "PR Open",
-                                            },
-                                            {
-                                                "label": "PR Review",
-                                                "value": "PR Review",
-                                            },
-                                            {
-                                                "label": "PR Comment",
-                                                "value": "PR Comment",
-                                            },
-                                        ],
-                                        value="Commit",
-                                        clearable=False,
-                                        className="dark-dropdown",
-                                    ),
-                                    className="me-2",
-                                    width=3,
-                                ),
-                                dbc.Alert(
-                                    children="""No contributions of this type have been made.\n
-                                        Please select a different contribution type.""",
-                                    id=f"check-alert-{PAGE}-{VIZ_ID}",
-                                    dismissable=True,
-                                    fade=False,
-                                    is_open=False,
-                                    color="warning",
-                                ),
-                                dbc.Label(
-                                    "Top K Contributors:",
-                                    html_for=f"top-k-contributors-{PAGE}-{VIZ_ID}",
-                                    width={"size": "auto"},
-                                ),
-                                dbc.Col(
-                                    dbc.Input(
-                                        id=f"top-k-contributors-{PAGE}-{VIZ_ID}",
-                                        type="number",
-                                        min=2,
-                                        max=100,
-                                        step=1,
-                                        value=10,
-                                        size="sm",
-                                        className="dark-input",
-                                    ),
-                                    className="me-2",
-                                    width=2,
-                                ),
-                                dbc.Col(
-                                    dcc.DatePickerRange(
-                                        id=f"date-picker-range-{PAGE}-{VIZ_ID}",
-                                        min_date_allowed=dt.date(2005, 1, 1),
-                                        max_date_allowed=dt.date.today(),
-                                        initial_visible_month=dt.date(dt.date.today().year, 1, 1),
-                                        clearable=True,
-                                        className="dark-date-picker",
-                                    ),
-                                    width=7,
-                                ),
-                            ],
-                            align="center",
-                            justify="start",
-                        ),
-                    ]
-                ),
-            ],
-            style={"padding": "1.5rem"},
+gc_contrib_importance_pie = VisualizationAIO(
+    PAGE,
+    VIZ_ID,
+    graph_info="""
+        AKA Bus factor. For a given action type, this visualizes the proportional share of the top k anonymous
+        contributors, aggregating the remaining contributors as "Other". Suppose Contributor A
+        opens the most PRs of all contributors, accounting for 1/5 of all PRs. If k = 1,
+        then the chart will have one slice for Contributor A accounting for 1/5 of the area,
+        with the remaining 4/5 representing all other contributors. Note: Some commits may have a
+        Contributor ID of 'None' if there is no GitHub account is associated with the email that
+        the contributor committed as.
+        """,
+    controls=[
+        dbc.Label(
+            "Action Type:",
+            html_for=f"action-type-{PAGE}-{VIZ_ID}",
+            width={"size": "auto"},
+        ),
+        dbc.Col(
+            dcc.Dropdown(
+                id=f"action-type-{PAGE}-{VIZ_ID}",
+                options=[
+                    {"label": "Commit", "value": "Commit"},
+                    {
+                        "label": "Issue Opened",
+                        "value": "Issue Opened",
+                    },
+                    {
+                        "label": "Issue Comment",
+                        "value": "Issue Comment",
+                    },
+                    {
+                        "label": "Issue Closed",
+                        "value": "Issue Closed",
+                    },
+                    {
+                        "label": "PR Open",
+                        "value": "PR Open",
+                    },
+                    {
+                        "label": "PR Review",
+                        "value": "PR Review",
+                    },
+                    {
+                        "label": "PR Comment",
+                        "value": "PR Comment",
+                    },
+                ],
+                value="Commit",
+                clearable=False,
+                className="dark-dropdown",
+            ),
+            className="me-2",
+            width=3,
+        ),
+        dbc.Alert(
+            children="""No contributions of this type have been made.\n
+                Please select a different contribution type.""",
+            id=f"check-alert-{PAGE}-{VIZ_ID}",
+            dismissable=True,
+            fade=False,
+            is_open=False,
+            color="warning",
+        ),
+        dbc.Label(
+            "Top K Contributors:",
+            html_for=f"top-k-contributors-{PAGE}-{VIZ_ID}",
+            width={"size": "auto"},
+        ),
+        dbc.Col(
+            dbc.Input(
+                id=f"top-k-contributors-{PAGE}-{VIZ_ID}",
+                type="number",
+                min=2,
+                max=100,
+                step=1,
+                value=10,
+                size="sm",
+                className="dark-input",
+            ),
+            className="me-2",
+            width=2,
+        ),
+        dbc.Col(
+            dcc.DatePickerRange(
+                id=f"date-picker-range-{PAGE}-{VIZ_ID}",
+                min_date_allowed=dt.date(2005, 1, 1),
+                max_date_allowed=dt.date.today(),
+                initial_visible_month=dt.date(dt.date.today().year, 1, 1),
+                clearable=True,
+                className="dark-date-picker",
+            ),
+            width=7,
         ),
     ],
-    className="dark-card",
+    class_name="dark-card",
     id="bus-factor",
 )
-
-
-# callback for graph info popover
-@callback(
-    Output(f"popover-{PAGE}-{VIZ_ID}", "is_open"),
-    [Input(f"popover-target-{PAGE}-{VIZ_ID}", "n_clicks")],
-    [State(f"popover-{PAGE}-{VIZ_ID}", "is_open")],
-)
-def toggle_popover(n, is_open):
-    if n:
-        return not is_open
-    return is_open
 
 
 # callback for dynamically changing the graph title

--- a/8Knot/pages/chaoss/visualizations/contrib_importance_pie.py
+++ b/8Knot/pages/chaoss/visualizations/contrib_importance_pie.py
@@ -1,8 +1,7 @@
-from dash import html, dcc, callback
+from dash import dcc, callback
 import dash
 import dash_bootstrap_components as dbc
-import dash_mantine_components as dmc
-from dash.dependencies import Input, Output, State
+from dash.dependencies import Input, Output
 import plotly.graph_objects as go
 import pandas as pd
 import logging

--- a/8Knot/pages/chaoss/visualizations/contrib_importance_pie.py
+++ b/8Knot/pages/chaoss/visualizations/contrib_importance_pie.py
@@ -1,6 +1,5 @@
 from dash import html, dcc, callback
 import dash
-from dash import dcc
 import dash_bootstrap_components as dbc
 import dash_mantine_components as dmc
 from dash.dependencies import Input, Output, State
@@ -31,7 +30,7 @@ gc_contrib_importance_pie = VisualizationAIO(
         opens the most PRs of all contributors, accounting for 1/5 of all PRs. If k = 1,
         then the chart will have one slice for Contributor A accounting for 1/5 of the area,
         with the remaining 4/5 representing all other contributors. Note: Some commits may have a
-        Contributor ID of 'None' if there is no GitHub account is associated with the email that
+        Contributor ID of 'None' if no GitHub account is associated with the email that
         the contributor committed as.
         """,
     controls=[

--- a/8Knot/pages/visualization_template/viz_template.py
+++ b/8Knot/pages/visualization_template/viz_template.py
@@ -12,6 +12,7 @@ from queries.QUERY_NAME import QUERY_NAME as QUERY_INITIALS
 import io
 import cache_manager.cache_facade as cf
 from pages.utils.job_utils import nodata_graph
+from components.visualization import VisualizationAIO
 import time
 import app
 
@@ -23,13 +24,14 @@ NOTE: VARIABLES TO CHANGE:
 (3) gc_VISUALIZATION
 (4) TITLE OF VISUALIZATION
 (5) CONTEXT OF GRAPH
-(6) IDs of Dash components
-(6) NAME_OF_VISUALIZATION_graph
-(7) COLUMN_WITH_DATETIME
-(8) COLUMN_WITH_DATETIME
-(9) COLUMN_TO_SORT_BY
-(10) Comments before callbacks
-(11) QUERY_USED, QUERY_NAME, QUERY_INITIALS
+(6) URL-FRIENDLY-IDENTIFIER
+(7) IDs of Dash components
+(8) NAME_OF_VISUALIZATION_graph
+(9) COLUMN_WITH_DATETIME
+(10) COLUMN_WITH_DATETIME
+(11) COLUMN_TO_SORT_BY
+(12) Comments before callbacks
+(13) QUERY_USED, QUERY_NAME, QUERY_INITIALS
 
 NOTE: Data queried from Augur is a Postgres->Postgres transaction. If the data that resides in cache requires a pre-processing
         step before it can be used in analysis, it will likely reside in 8Knot/8Knot/pages/utils/preprocessing_utils.py, but "your mileage my vary".
@@ -37,7 +39,7 @@ NOTE: Data queried from Augur is a Postgres->Postgres transaction. If the data t
 NOTE: IMPORTING A VISUALIZATION INTO A PAGE
 (1) Include the visualization file in the visualization folder for the respective page
 (2) Import the visualization into the page_name.py file using "from .visualizations.visualization_file_name import gc_visualization_name"
-(3) Add the card into a column in a row on the page
+(3) Add the card into new row on the page
 
 NOTE: ADDITIONAL DASH COMPONENTS FOR USER GRAPH CUSTOMIZATIONS
 
@@ -58,129 +60,93 @@ For more information, check out the new_vis_guidance.md
 PAGE = "page-name"  # EDIT FOR CURRENT PAGE
 VIZ_ID = "shortname-of-viz"  # UNIQUE IDENTIFIER FOR VIZUALIZATION
 
-gc_VISUALIZATION = dbc.Card(
-    [
-        dbc.CardBody(
-            [
-                html.H3(
-                    "TITLE OF VISUALIZATION",
-                    className="card-title",
-                    style={"textAlign": "center"},
-                ),
-                dbc.Popover(
-                    [
-                        dbc.PopoverHeader("Graph Info:"),
-                        dbc.PopoverBody("INSERT CONTEXT OF GRAPH HERE"),
-                    ],
-                    id=f"popover-{PAGE}-{VIZ_ID}",
-                    target=f"popover-target-{PAGE}-{VIZ_ID}",
-                    placement="top",
-                    is_open=False,
-                ),
-                dcc.Loading(
-                    dcc.Graph(id=f"{PAGE}-{VIZ_ID}"),
-                ),
-                dbc.Form(
-                    [
-                        dbc.Row(
-                            [
-                                dbc.Label(
-                                    "Date Interval:",
-                                    html_for=f"date-radio-{PAGE}-{VIZ_ID}",
-                                    width="auto",
-                                ),
-                                dbc.Col(
-                                    [
-                                        dbc.RadioItems(
-                                            id=f"date-radio-{PAGE}-{VIZ_ID}",
-                                            options=[
-                                                {
-                                                    "label": "Trend",
-                                                    "value": "D",
-                                                },  # TREND IF LINE, DAY IF NOT
-                                                # {"label": "Week","value": "W",}, UNCOMMENT IF APPLICABLE
-                                                {"label": "Month", "value": "M"},
-                                                {"label": "Year", "value": "Y"},
-                                            ],
-                                            value="M",
-                                            inline=True,
-                                        ),
-                                    ]
-                                ),
-                                dbc.Col(
-                                    dbc.Button(
-                                        "About Graph",
-                                        id=f"popover-target-{PAGE}-{VIZ_ID}",
-                                        color="secondary",
-                                        size="sm",
-                                    ),
-                                    width="auto",
-                                    style={"paddingTop": ".5em"},
-                                ),
-                            ],
-                            align="center",
-                        ),
-                        # TODO: ADD IN IF ADDITIONAL PARAMETERS FOR GRAPH, REMOVE IF NOT
-                        """ format dbc.Inputs, including dbc.Alert if needed
-                                dbc.Label(
-                                    "TITLE_OF_ADDITIONAL_PARAMETER:",
-                                    html_for=f"component-identifier-{PAGE}-{VIZ_ID}",
-                                    width={"size": "auto"},
-                                ),
-                                dbc.Col(
-                                    dbc.Input(
-                                        id=f"component-identifier-{PAGE}-{VIZ_ID}",,
-                                        type="number",
-                                        min=1,
-                                        max=120,
-                                        step=1,
-                                        value=7,
-                                    ),
-                                    className="me-2",
-                                    width=2,
-                                ),
-                                dbc.Alert(
-                                    children="Please ensure that 'PARAMETER' is less than 'PARAMETER'",
-                                    id=f"component-identifier-{PAGE}-{VIZ_ID}",
-                                    dismissable=True,
-                                    fade=False,
-                                    is_open=False,
-                                    color="warning",
-                                ),
-                        """
-                        """ format for dcc.DatePickerRange:
-                                dbc.Col(
-                                    dcc.DatePickerRange(
-                                        id=f"component-identifier-{PAGE}-{VIZ_ID}",
-                                        min_date_allowed=dt.date(2005, 1, 1),
-                                        max_date_allowed=dt.date.today(),
-                                        clearable=True,
-                                    ),
-                                    width="auto",
-                                ),
 
-                        """,
+gc_VISUALIZATION = VisualizationAIO(
+    PAGE,
+    VIZ_ID,
+    title="TITLE OF VISUALIZATION",
+    graph_info="""
+        CONTEXT OF GRAPH
+    """,
+    controls=[
+        dbc.Row(
+            [
+                dbc.Label(
+                    "Date Interval:",
+                    html_for=f"date-radio-{PAGE}-{VIZ_ID}",
+                    width="auto",
+                ),
+                dbc.Col(
+                    [
+                        dbc.RadioItems(
+                            id=f"date-radio-{PAGE}-{VIZ_ID}",
+                            options=[
+                                {
+                                    "label": "Trend",
+                                    "value": "D",
+                                },  # TREND IF LINE, DAY IF NOT
+                                # {"label": "Week","value": "W",}, UNCOMMENT IF APPLICABLE
+                                {"label": "Month", "value": "M"},
+                                {"label": "Year", "value": "Y"},
+                            ],
+                            value="M",
+                            inline=True,
+                        ),
                     ]
                 ),
-            ]
-        )
+            ],
+            align="center",
+        ),
+        # TODO: ADD IN IF ADDITIONAL PARAMETERS FOR GRAPH, REMOVE IF NOT
+        """ format dbc.Inputs, including dbc.Alert if needed
+                dbc.Label(
+                    "TITLE_OF_ADDITIONAL_PARAMETER:",
+                    html_for=f"component-identifier-{PAGE}-{VIZ_ID}",
+                    width={"size": "auto"},
+                ),
+                dbc.Col(
+                    dbc.Input(
+                        id=f"component-identifier-{PAGE}-{VIZ_ID}",
+                        type="number",
+                        min=1,
+                        max=120,
+                        step=1,
+                        value=7,
+                    ),
+                    className="me-2",
+                    width=2,
+                ),
+                dbc.Alert(
+                    children="Please ensure that 'PARAMETER' is less than 'PARAMETER'",
+                    id=f"component-identifier-{PAGE}-{VIZ_ID}",
+                    dismissable=True,
+                    fade=False,
+                    is_open=False,
+                    color="warning",
+                ),
+        """
+        """ format for dcc.DatePickerRange:
+                dbc.Col(
+                    dcc.DatePickerRange(
+                        id=f"component-identifier-{PAGE}-{VIZ_ID}",
+                        min_date_allowed=dt.date(2005, 1, 1),
+                        max_date_allowed=dt.date.today(),
+                        clearable=True,
+                    ),
+                    width="auto",
+                ),
+
+        """,
     ],
+    class_name="dark-card",
+    id="URL-FRIENDLY-IDENTIFIER",
 )
 
 
-# callback for graph info popover
-@callback(
-    Output(f"popover-{PAGE}-{VIZ_ID}", "is_open"),
-    [Input(f"popover-target-{PAGE}-{VIZ_ID}", "n_clicks")],
-    [State(f"popover-{PAGE}-{VIZ_ID}", "is_open")],
-)
-def toggle_popover(n, is_open):
-    if n:
-        return not is_open
-    return is_open
-
-
-# callback for VIZ TITLE graph
+# callback for VIZ TITLE graph.
+# This is helpful if you want a dynamic title that includes parameters about the current graph configuration
+# for example "Number of contributors in the past N months" (where N is a value the user can set)
+# This will take precedence over any static title set above
 @callback(
     Output(f"{PAGE}-{VIZ_ID}", "figure"),
     # Output(f"check-alert-{PAGE}-{VIZ_ID}", "is_open"), USE WITH ADDITIONAL PARAMETERS

--- a/8Knot/pages/visualization_template/viz_template.py
+++ b/8Knot/pages/visualization_template/viz_template.py
@@ -9,12 +9,11 @@ from dateutil.relativedelta import *  # type: ignore
 import plotly.express as px
 from pages.utils.graph_utils import get_graph_time_values, color_seq
 from queries.QUERY_NAME import QUERY_NAME as QUERY_INITIALS
-import io
 import cache_manager.cache_facade as cf
 from pages.utils.job_utils import nodata_graph
 from components.visualization import VisualizationAIO
 import time
-import app
+import app # pylint: disable=unused-import
 
 """
 NOTE: VARIABLES TO CHANGE:

--- a/docs/new_viz_guidance.md
+++ b/docs/new_viz_guidance.md
@@ -16,11 +16,11 @@ to get up-and-running quickly.
 
 Please try to understand the architecture by reading the code before you begin
 any of your own development work. There are few "gotchas" but some are unavoidable.
-A recommended way of doing this is to start by looking at /pages/overview/overview.py.
+A recommended way of doing this is to start by looking at `8Knot/pages/repo_overview/repo_overview.py`.
 This file sketches the markup of the Overview page. You'll see that we import
 the files that have the appropriate callback functions for the pages' figures from
-/pages/overview/visualizations. In this respect, we aim to isolate larger logical
-"chunks" of our application- the page's structure is higher in the hierarchy, and
+`8Knot/pages/repo_overview/visualizations`. In this respect, we aim to isolate larger logical
+"chunks" of our application - the page's structure is higher in the hierarchy, and
 individual visualizations are imported and further organized below.
 
 ### Visualization Template
@@ -31,7 +31,7 @@ The [Visualization Template](https://github.com/oss-aspen/8Knot/blob/dev/8Knot/p
 
 Assuming that you already have the appropriate credentials to access our Augur
 database instance (or have your own), you'll find that the queries to our
-Database are in the folder /queries/. These queries may be reused across multiple
+Database are in the folder `8Knot/queries`. These queries may be reused across multiple
 visualizations. When considering creating your own visualization, please
 see whether the available queries to our database instance are sufficient.
 
@@ -41,41 +41,41 @@ new columns or aggregations, to existing queries.
 2. If a completely new query is necessary, use the [Query Template](https://github.com/oss-aspen/8Knot/blob/dev/8Knot/queries/query_template.py)
 to build a new query.
 
-Note: make sure to do a "docker compose down" before rebuilding to be able to access any new or edited queries.
+Note: make sure to do a `docker compose down` before rebuilding to be able to access any new or edited queries.
 
 ### Importing your queries
 
 If you look at the import list at the top of a visualization file such as
-/pages/visualizations/overview/commits\_over\_time.py, you'll find that we
-import the query function /queries/commits\_query.py.
+`8Knot/pages/contributions/visualizations/commits_over_time.py`, you'll find that we
+import the query function `8Knot/queries/commits_query.py`.
 
 In the new visualization you're creating, please make sure to import the relevant
 query in this way, and please also make sure to name this import by a sensible
 short-hand if it's a query you've written, or use the short-hand that we've chosen
 for queries used elsewhere:
 
-e.g. "from queries.commits\_query import commits\_query as cmq"
+e.g. `from queries.commits_query import commits_query as cmq`
 
 ### Using your queries
 
-We've written a utility (/pages/utils/job\_utils.py) and a job manager
-(/job\_manager/job\_manager.py) to make your life as easy as possible. Please
+We've written a utility (`8Knot/pages/utils/job_utils.py`) and a cache manager
+(`8Knot/cache_manager/cache_manager.py`) to make your life as easy as possible. Please
 read through those files to understand what they're doing generally, but
 feel no responsibility to dive very deep if that isn't your area of interest.
 Instead, follow the format of other queries that are already available.
 
-Use our Job Manager interface as shown in other visualization files and the visualization template. A common error
+Use our Cache Manager interface as shown in other visualization files and the visualization template. A common error
 is to copy the use of the manager from any other visualization callback and to not
 replace the query function short-hand reference. For instance, if another visualization used
-"commits\_query", named cmq as we described earlier, but you were intending to use
-another query, you would need to replace "cmq" with your specific query short-hand in the following:
+`commits_query`, named `cmq` as we described earlier, but you were intending to use
+another query, you would need to replace `cmq` with your specific query short-hand in the following:
 
-"""
-ready, results, graph\_update, interval\_update = handle\_job\_state(jm, cmq, repolist)
+```python
+ready, results, graph_update, interval_update = handle_job_state(jm, cmq, repolist)
 if not ready:
     # set n_intervals to 0 so it'll fire again.
     return graph_update, interval_update
-"""
+```
 
 This code-block is our solution to the challenge of abstracting-away all of the
 background-worker and caching logic necessary to make this app run.


### PR DESCRIPTION
Now that I have discovered a pattern for building custom components (as you may have seen in previous PRs), i have used this new superpower to ~~extract all demons~~ move a good chunk of the shared components of a visualization into one central place for maximum reuse.

This means the files defining each individual visualization are less bloated with stuff that "just needs to be included because every visualization needs it" (such as the dividers, and various structural elements).

This has been applied to one graph on the CHAOSS page if anyone is curious (meant to use the repo general info page but opened the wrong file and only realized after I was done) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a reusable All‑In‑One visualization card with integrated title, About popover, loading state, graph area, and controls.

* **Refactor**
  * Replaced handcrafted chart cards across multiple pages with the new visualization component for consistent layout and simpler wiring.
  * Consolidated title, controls, and info popovers into the unified component.

* **Documentation**
  * Updated guidance and path/name references to reflect the new visualization patterns and project structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->