### PR TITLE
UI fixes

### DIFF
--- a/8Knot/assets/color.css
+++ b/8Knot/assets/color.css
@@ -68,3 +68,38 @@
     --shadow-focus: rgba(64, 64, 64, 0.25);
     --shadow-subtle: rgba(199, 199, 199, 0.25);
 }
+
+
+/* ============================================================================
+   This section implements dynamic pill coloring:
+   - Grey pills by default when repos/orgs are selected
+   - Blue pills (like Data Ready badge) when search is executing
+
+   The .searching class is toggled by a callback in index_callbacks.py
+
+
+/* Style for filter pills (grey by default when selected) */
+
+.mantine-MultiSelect-pill,
+.mantine-MultiSelect-value {
+    background-color: var(--gray-medium);
+    color: var(--color-white);
+}
+
+.searchbar-dropdown .mantine-MultiSelect-pill,
+.searchbar-dropdown .mantine-MultiSelect-value {
+    background-color: var(--gray-medium);
+    color: var(--color-white);
+}
+
+
+/* Style for filter pills when search is active */
+
+
+/* !important needed to override inline styles from Mantine components */
+
+.searchbar-dropdown.searching .mantine-MultiSelect-pill,
+.searchbar-dropdown.searching .mantine-MultiSelect-value {
+    background-color: var(--baby-blue-700) !important;
+    color: var(--color-white) !important;
+}

--- a/8Knot/assets/landing_page.css
+++ b/8Knot/assets/landing_page.css
@@ -246,7 +246,7 @@
 }
 
 
-/* font_transition: */
+/* Updated tab hover color to baby-blue-300 for better UX */
 
 .landing-page .tabs-header .nav-tabs .nav-link:hover {
     background: var(--baby-blue-300);
@@ -306,9 +306,6 @@
     margin-bottom: var(--spacing-md);
 }
 
-
-/* UI-fixez: use background-color instead of color property */
-
 .landing-page .section-bordered {
     border: none;
     background-color: var(--color-topbar-bg);
@@ -348,9 +345,6 @@
     flex: 1;
     text-align: center;
 }
-
-
-/* UI-fixez: use defined token --border-radius-md */
 
 .landing-page .feature-image {
     max-width: 100%;
@@ -831,7 +825,7 @@
 }
 
 
-/* UI-fixez: Changed arrow to solid white using CSS filter */
+/* Changed arrow to solid white using CSS filter */
 
 .landing-page .arrow-image {
     width: 80px;
@@ -869,7 +863,7 @@
         padding: var(--landing-spacing-s-10) 0;
         min-width: auto;
     }
-    /* UI-fixez: Mobile arrow also solid white */
+    /* Mobile arrow also solid white */
     .landing-page .arrow-image {
         transform: rotate(90deg);
         width: 60px;

--- a/8Knot/assets/landing_page.css
+++ b/8Knot/assets/landing_page.css
@@ -245,8 +245,11 @@
     white-space: nowrap;
 }
 
+
+/* font_transition: */
+
 .landing-page .tabs-header .nav-tabs .nav-link:hover {
-    background: var(--hover-bg);
+    background: var(--baby-blue-300);
     color: var(--color-white);
     border-color: var(--baby-blue-500);
 }
@@ -303,10 +306,12 @@
     margin-bottom: var(--spacing-md);
 }
 
+
+/* UI-fixez: use background-color instead of color property */
+
 .landing-page .section-bordered {
-    background: transparent;
     border: none;
-    color: var(--color-topbar-bg);
+    background-color: var(--color-topbar-bg);
     border-radius: var(--landing-radius-md);
     padding: var(--spacing-lg);
     margin-top: var(--spacing-lg);
@@ -344,10 +349,13 @@
     text-align: center;
 }
 
+
+/* UI-fixez: use defined token --border-radius-md */
+
 .landing-page .feature-image {
     max-width: 100%;
     height: auto;
-    border-radius: var(--border-radius);
+    border-radius: var(--border-radius-md);
     border: 1px solid var(--color-border);
 }
 
@@ -822,10 +830,14 @@
     align-self: center;
 }
 
+
+/* UI-fixez: Changed arrow to solid white using CSS filter */
+
 .landing-page .arrow-image {
     width: 80px;
     height: auto;
-    opacity: 0.8;
+    opacity: 1;
+    filter: brightness(0) invert(1);
 }
 
 
@@ -857,9 +869,11 @@
         padding: var(--landing-spacing-s-10) 0;
         min-width: auto;
     }
+    /* UI-fixez: Mobile arrow also solid white */
     .landing-page .arrow-image {
         transform: rotate(90deg);
         width: 60px;
+        filter: brightness(0) invert(1);
     }
     .landing-page .before-image-container .image-caption,
     .landing-page .after-image-container .image-caption {

--- a/8Knot/assets/main_layout.css
+++ b/8Knot/assets/main_layout.css
@@ -390,10 +390,13 @@ a.sidebar-section-text {
 
 /* Style for filter pills when search is active */
 
+
+/* !important needed to override inline styles from Mantine components */
+
 .searchbar-dropdown.searching .mantine-MultiSelect-pill,
 .searchbar-dropdown.searching .mantine-MultiSelect-value {
-    background-color: var(--baby-blue-700);
-    color: var(--color-white);
+    background-color: var(--baby-blue-700) !important;
+    color: var(--color-white) !important;
 }
 
 

--- a/8Knot/assets/main_layout.css
+++ b/8Knot/assets/main_layout.css
@@ -362,6 +362,44 @@ a.sidebar-section-text {
 }
 
 
+/* ============================================================================
+   UI-fixez: Filter Pill Styles for Active Search State
+
+   This section implements dynamic pill coloring:
+   - Grey pills by default when repos/orgs are selected
+   - Blue pills (like Data Ready badge) when search is executing
+
+   The .searching class is toggled by a callback in index_callbacks.py
+============================================================================ */
+
+
+/* Style for filter pills (grey by default when selected) */
+
+.mantine-MultiSelect-pill,
+.mantine-MultiSelect-value {
+    background-color: var(--gray-medium);
+    color: var(--color-white);
+}
+
+.searchbar-dropdown .mantine-MultiSelect-pill,
+.searchbar-dropdown .mantine-MultiSelect-value {
+    background-color: var(--gray-medium);
+    color: var(--color-white);
+}
+
+
+/* Style for filter pills when search is active */
+
+.searchbar-dropdown.searching .mantine-MultiSelect-pill,
+.searchbar-dropdown.searching .mantine-MultiSelect-value {
+    background-color: var(--baby-blue-700);
+    color: var(--color-white);
+}
+
+
+/* End UI-fixez pill styles */
+
+
 /* visualization adjustments */
 
 .visualization-row {

--- a/8Knot/assets/main_layout.css
+++ b/8Knot/assets/main_layout.css
@@ -362,47 +362,6 @@ a.sidebar-section-text {
 }
 
 
-/* ============================================================================
-   UI-fixez: Filter Pill Styles for Active Search State
-
-   This section implements dynamic pill coloring:
-   - Grey pills by default when repos/orgs are selected
-   - Blue pills (like Data Ready badge) when search is executing
-
-   The .searching class is toggled by a callback in index_callbacks.py
-============================================================================ */
-
-
-/* Style for filter pills (grey by default when selected) */
-
-.mantine-MultiSelect-pill,
-.mantine-MultiSelect-value {
-    background-color: var(--gray-medium);
-    color: var(--color-white);
-}
-
-.searchbar-dropdown .mantine-MultiSelect-pill,
-.searchbar-dropdown .mantine-MultiSelect-value {
-    background-color: var(--gray-medium);
-    color: var(--color-white);
-}
-
-
-/* Style for filter pills when search is active */
-
-
-/* !important needed to override inline styles from Mantine components */
-
-.searchbar-dropdown.searching .mantine-MultiSelect-pill,
-.searchbar-dropdown.searching .mantine-MultiSelect-value {
-    background-color: var(--baby-blue-700) !important;
-    color: var(--color-white) !important;
-}
-
-
-/* End UI-fixez pill styles */
-
-
 /* visualization adjustments */
 
 .visualization-row {

--- a/8Knot/pages/index/index_callbacks.py
+++ b/8Knot/pages/index/index_callbacks.py
@@ -877,7 +877,7 @@ def hide_loading_on_landing(pathname):
     [Input("search", "n_clicks"), Input("projects", "value")],
     prevent_initial_call=True,
 )
-def update_pill_color_on_search(search_button_clicks, selected_repos_orgs):
+def update_pill_color_on_search(_, selected_repos_orgs):
     """Update pill color based on search action.
 
     When search icon is clicked, add 'searching' class to turn pills blue.

--- a/8Knot/pages/index/index_callbacks.py
+++ b/8Knot/pages/index/index_callbacks.py
@@ -860,3 +860,41 @@ def hide_loading_on_landing(pathname):
 
 
 # Note: Landing page callbacks moved to pages/landing/landing_callbacks.py
+
+
+# ============================================================================
+# UI-fixez: Callback to change pill color when search is clicked
+#
+# This callback implements dynamic pill coloring:
+# - When user selects repos/orgs: pills are grey (pending)
+# - When user clicks search icon: pills turn blue (active search)
+# - Default selection (chaoss) starts blue since search is auto-triggered
+#
+# Works in conjunction with CSS in main_layout.css
+# ============================================================================
+@callback(
+    Output("projects", "className"),
+    [Input("search", "n_clicks"), Input("projects", "value")],
+    prevent_initial_call=True,
+)
+def update_pill_color_on_search(search_clicks, selected_values):
+    """Update pill color based on search action.
+
+    When search icon is clicked, add 'searching' class to turn pills blue.
+    When values change (user is selecting), remove 'searching' class to keep pills grey.
+    """
+    if not dash.ctx.triggered:
+        return dash.no_update
+
+    triggered_id = dash.ctx.triggered_id
+
+    if triggered_id == "search":
+        # Search button clicked - add 'searching' class to turn pills blue
+        logging.info(f"PILL COLOR: Search clicked - turning pills BLUE")
+        return "searchbar-dropdown searching"
+    if triggered_id == "projects":
+        # Values changed (user selecting) - remove 'searching' class to keep pills grey
+        logging.info(f"PILL COLOR: Values changed - turning pills GREY. Selected: {selected_values}")
+        return "searchbar-dropdown"
+
+    return dash.no_update

--- a/8Knot/pages/index/index_callbacks.py
+++ b/8Knot/pages/index/index_callbacks.py
@@ -863,7 +863,7 @@ def hide_loading_on_landing(pathname):
 
 
 # ============================================================================
-# UI-fixez: Callback to change pill color when search is clicked
+# Callback to change pill color when search is clicked
 #
 # This callback implements dynamic pill coloring:
 # - When user selects repos/orgs: pills are grey (pending)
@@ -877,7 +877,7 @@ def hide_loading_on_landing(pathname):
     [Input("search", "n_clicks"), Input("projects", "value")],
     prevent_initial_call=True,
 )
-def update_pill_color_on_search(search_clicks, selected_values):
+def update_pill_color_on_search(search_button_clicks, selected_repos_orgs):
     """Update pill color based on search action.
 
     When search icon is clicked, add 'searching' class to turn pills blue.
@@ -894,7 +894,7 @@ def update_pill_color_on_search(search_clicks, selected_values):
         return "searchbar-dropdown searching"
     if triggered_id == "projects":
         # Values changed (user selecting) - remove 'searching' class to keep pills grey
-        logging.info(f"PILL COLOR: Values changed - turning pills GREY. Selected: {selected_values}")
+        logging.info(f"PILL COLOR: Values changed - turning pills GREY. Selected: {selected_repos_orgs}")
         return "searchbar-dropdown"
 
     return dash.no_update

--- a/8Knot/pages/index/index_layout.py
+++ b/8Knot/pages/index/index_layout.py
@@ -213,7 +213,8 @@ search_bar = html.Div(
                             debounce=100,  # debounce time for the search input, since we're implementing client-side caching, we can use a faster debounce
                             data=[augur.initial_multiselect_option()],
                             value=[augur.initial_multiselect_option()["value"]],
-                            className="searchbar-dropdown",
+                            # UI-fixez: Start with "searching" class so default selection (chaoss) shows as blue
+                            className="searchbar-dropdown searching",
                             styles={
                                 "input": {
                                     "fontSize": "16px",
@@ -237,6 +238,15 @@ search_bar = html.Div(
                                 "item": {
                                     "borderRadius": "8px",
                                     "margin": "2px 4px",
+                                    "color": "white",
+                                },
+                                # UI-fixez: Inline styles for grey pill default color
+                                "value": {
+                                    "backgroundColor": "#555555",
+                                    "color": "white",
+                                },
+                                "pill": {
+                                    "backgroundColor": "#555555",
                                     "color": "white",
                                 },
                             },
@@ -266,10 +276,12 @@ search_bar = html.Div(
                     style={"position": "relative"},
                 ),
                 dbc.Alert(
+                    # UI-fixez: Updated help text to explain pill color behavior
                     children='Please ensure that your spelling is correct. \
                         If your selection definitely isn\'t present, please request that \
                         it be loaded using the help button "REPO/ORG Request" \
-                        in the bottom right corner of the screen.',
+                        in the bottom right corner of the screen.  \
+                        The search is only confirmed when you click the search icon and the pill turns blue.',
                     id="help-alert",
                     dismissable=True,
                     fade=True,

--- a/8Knot/pages/index/index_layout.py
+++ b/8Knot/pages/index/index_layout.py
@@ -213,7 +213,7 @@ search_bar = html.Div(
                             debounce=100,  # debounce time for the search input, since we're implementing client-side caching, we can use a faster debounce
                             data=[augur.initial_multiselect_option()],
                             value=[augur.initial_multiselect_option()["value"]],
-                            # UI-fixez: Start with "searching" class so default selection (chaoss) shows as blue
+                            # Start with "searching" class so default selection (chaoss) shows as blue
                             className="searchbar-dropdown searching",
                             styles={
                                 "input": {
@@ -240,7 +240,7 @@ search_bar = html.Div(
                                     "margin": "2px 4px",
                                     "color": "white",
                                 },
-                                # UI-fixez: Inline styles for grey pill default color
+                                # Inline styles for grey pill default color
                                 "value": {
                                     "backgroundColor": "#555555",
                                     "color": "white",
@@ -276,7 +276,7 @@ search_bar = html.Div(
                     style={"position": "relative"},
                 ),
                 dbc.Alert(
-                    # UI-fixez: Updated help text to explain pill color behavior
+                    # Updated help text to explain pill color behavior
                     children='Please ensure that your spelling is correct. \
                         If your selection definitely isn\'t present, please request that \
                         it be loaded using the help button "REPO/ORG Request" \


### PR DESCRIPTION
This PR fixes a few things on the UI and aims to resolve confusion over what's been actively searching or not. 


Fixes:
- Arrows are now white on the graphs within the first tab;
- On the search bar, when user selects something, the pill will remain grey if it's pending or inactive, and will turn into blue when user clicks on the search icon, which means active search for that repo/org. 
- Info card has been updated to inform the user about this feature. 
- tab hover colors also modified to baby-blue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clearer search interaction: pills indicate active/searching state and help text clarifies confirmation behavior

* **Style**
  * Unified design tokens for colors, spacing, typography, radii, shadows and transitions
  * Restyled filter pills, multi-select, hover/focus states, image borders, captions and responsive layouts
  * Scoped landing-page styles to reduce global styling bleed

* **Refactor**
  * Large theme/token overhaul for consistent, token-driven theming and easier maintenance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->