### PR TITLE
Truncating selected pills for the search bar

### DIFF
--- a/8Knot/assets/main_layout.css
+++ b/8Knot/assets/main_layout.css
@@ -318,6 +318,16 @@ a.sidebar-section-text {
     color: var(--color-white);
 }
 
+
+/* Truncate long names in search bar pills (selected items) */
+
+.searchbar-dropdown .mantine-Pill-label {
+    max-width: 200px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
 .search-icon {
     background-color: transparent;
     border: none;


### PR DESCRIPTION
This PR resolves the issue #959 

Repos/Orgs with big names overflowing or not being displayed properly. 


### Generative AI disclosure
<!-- To learn more about our Generative AI policy and required disclosures, see the `CONTRIBUTING.md` file -->
- [x] This contribution was assisted or created by Generative AI tools.
    - What tools were used? Claude-4.5-Opus-High
    - How were these tools used? Initial Drafts, Ideation, Prototyping. 
    - Did you review these outputs before submitting this PR? Yes, manually reviewed all code and made modifications accordingly. 
