### PR TITLE
Add .gitattributes for consistent line ending handling

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,42 @@
+# Set default behavior to automatically normalize line endings
+* text=auto
+
+# Python files should always use LF line endings
+*.py text eol=lf
+
+# Shell scripts should always use LF line endings
+*.sh text eol=lf
+
+# Batch files should use CRLF (Windows)
+*.bat text eol=crlf
+*.cmd text eol=crlf
+
+# Configuration files that may be used in containers/Linux
+Dockerfile text eol=lf
+docker-compose*.yml text eol=lf
+*.yaml text eol=lf
+*.yml text eol=lf
+Makefile text eol=lf
+
+# Explicitly declare text files to avoid ambiguity
+*.md text
+*.txt text
+*.json text
+*.toml text
+*.cfg text
+*.ini text
+*.html text
+*.css text
+*.js text
+
+# Binary files - do not modify
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.pdf binary
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.eot binary


### PR DESCRIPTION
## Summary
- Adds `.gitattributes` file to ensure Python files always use LF line endings
- Prevents CRLF issues when Windows contributors submit changes
- Addresses the root cause mentioned in #1061

## Changes
- Created `.gitattributes` with rules for:
  - Python files (`*.py`) - always LF
  - Shell scripts (`*.sh`) - always LF  
  - Docker/config files - always LF
  - Batch files (`*.bat`, `*.cmd`) - always CRLF (Windows-native)
  - Binary files - no modification

## Test plan
- [x] Verify file is correctly formatted
- [ ] Existing contributors can verify their local line endings normalize correctly

Fixes #1062