### PR TITLE
Add explicit "AI was not used" option to AI disclosure template (#1080)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,8 +3,9 @@
 
 Please select one option:
 
-- [ ] This contribution was assisted or created by Generative AI tools.
 - [ ] This contribution was NOT assisted or created by Generative AI tools.
+- [ ] This contribution was assisted or created by Generative AI tools.
+
 
 If AI tools were used, please provide details below:
     - What tools were used? <!-- gemini / chatgpt / claude .etc -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,12 @@
-
-
 ### Generative AI disclosure
 <!-- To learn more about our Generative AI policy and required disclosures, see the `CONTRIBUTING.md` file -->
+
+Please select one option:
+
 - [ ] This contribution was assisted or created by Generative AI tools.
-    - What tools were used? <!--gemini / chatgpt / claude .etc -->
-    - How were these tools used? <!-- initial draft of the code / code review / writing tests .etc-->
+- [ ] This contribution was NOT assisted or created by Generative AI tools.
+
+If AI tools were used, please provide details below:
+    - What tools were used? <!-- gemini / chatgpt / claude .etc -->
+    - How were these tools used? <!-- initial draft of the code / code review / writing tests .etc -->
     - Did you review these outputs before submitting this PR? <!-- No / Yes and I made these fixes... -->


### PR DESCRIPTION
## Summary

This PR updates the Generative AI disclosure section in the pull request template to include an explicit negative option.

## Previous Behavior

Previously, the template only included:

- [ ] This contribution was assisted or created by Generative AI tools.

This assumed AI usage and did not provide a way to explicitly indicate that AI tools were not used.

## Updated Behavior

The template now includes two explicit options:

- [ ] This contribution was assisted or created by Generative AI tools.
- [ ] This contribution was NOT assisted or created by Generative AI tools.

Additional details are still required only if AI tools were used.

## Motivation

This change helps distinguish between:
- A contribution where AI was not used
- A contributor unintentionally leaving the section incomplete

This aligns with recent AI policy updates in Augur.

Closes #1080
