### PR TITLE
Increasing soft time limit on worker-callback 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,7 @@ services:
     build:
       context: .
       dockerfile: ./docker/Dockerfile
-    command: ["celery", "-A", "app:celery_app", "worker", "--loglevel=INFO", "--concurrency=1", "--time-limit=300", "--soft-time-limit=240"]
+    command: ["celery", "-A", "app:celery_app", "worker", "--loglevel=INFO", "--concurrency=1", "--time-limit=700", "--soft-time-limit=630"]
     depends_on:
       - redis-cache
       - redis-users


### PR DESCRIPTION
This PR aims to resolve issue #1083 on the larger repos loading data issue.
Loading data for larger repos was taking significantly more time than the worker-callback softime limit, after that a reset/reload command was also triggered because of that, pointing back to the org Chaoss by default.
Increasing the time limits on the worker-callback aligned and in sync with the already increased worker-query time limits should resolve the issue. 


### Generative AI disclosure
<!-- To learn more about our Generative AI policy and required disclosures, see the `CONTRIBUTING.md` file -->

Please select one option:

- [x] This contribution was NOT assisted or created by Generative AI tools.
- [ ] This contribution was assisted or created by Generative AI tools.


If AI tools were used, please provide details below:
    - What tools were used? <!-- gemini / chatgpt / claude .etc -->
    - How were these tools used? <!-- initial draft of the code / code review / writing tests .etc -->
    - Did you review these outputs before submitting this PR? <!-- No / Yes and I made these fixes... -->
