### PR TITLE
limit reviewdog to only reviewing lint changes in the changed diff (rather than the whole file)

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -49,4 +49,4 @@ jobs:
           reporter: github-pr-review
           level: warning
           glob_pattern: "**/*.py"
-          filter_mode: "file"
+          filter_mode: "diff_context"


### PR DESCRIPTION
This makes reviewdog less annoying

This was also done in upstream augur so this fix is basically taken from https://github.com/chaoss/augur/pull/3659

### Generative AI disclosure
<!-- To learn more about our Generative AI policy and required disclosures, see the `CONTRIBUTING.md` file -->

Please select one option:

- [X] This contribution was NOT assisted or created by Generative AI tools.
- [ ] This contribution was assisted or created by Generative AI tools.


If AI tools were used, please provide details below:
    - What tools were used? <!-- gemini / chatgpt / claude .etc -->
    - How were these tools used? <!-- initial draft of the code / code review / writing tests .etc -->
    - Did you review these outputs before submitting this PR? <!-- No / Yes and I made these fixes... -->
