### PR TITLE
update affiliations query to inlcude emails in contributors table

### DIFF
--- a/8Knot/queries/affiliation_query.py
+++ b/8Knot/queries/affiliation_query.py
@@ -44,16 +44,12 @@ def affiliation_query(self, repos):
                         con.cntrb_company,
                         array_to_string(
                             ARRAY(
-                                SELECT DISTINCT unnest(
-                                    array_remove(
-                                        array_remove(
-                                            array_agg(ca.alias_email) ||
-                                            ARRAY[con.cntrb_email, con.cntrb_canonical],
-                                            NULL
-                                        ),
-                                        ''
-                                    )
-                                )
+                                SELECT DISTINCT e
+                                FROM unnest(
+                                    array_agg(ca.alias_email) ||
+                                    ARRAY[con.cntrb_email, con.cntrb_canonical]
+                                ) AS e
+                                WHERE e IS NOT NULL AND e != ''
                             ), ' , '
                         ) AS email_list
                     FROM

--- a/8Knot/queries/affiliation_query.py
+++ b/8Knot/queries/affiliation_query.py
@@ -42,7 +42,20 @@ def affiliation_query(self, repos):
                         c.action,
                         c.rank,
                         con.cntrb_company,
-                        string_agg(ca.alias_email, ' , ' order by ca.alias_email) as email_list
+                        array_to_string(
+                            ARRAY(
+                                SELECT DISTINCT unnest(
+                                    array_remove(
+                                        array_remove(
+                                            array_agg(ca.alias_email) ||
+                                            ARRAY[con.cntrb_email, con.cntrb_canonical],
+                                            NULL
+                                        ),
+                                        ''
+                                    )
+                                )
+                            ), ' , '
+                        ) AS email_list
                     FROM
                         explorer_contributor_actions c
                     JOIN contributors_aliases ca
@@ -53,7 +66,7 @@ def affiliation_query(self, repos):
                         c.repo_id in %s
                         and timezone('utc', c.created_at) < now() -- created_at is a timestamptz value
                         -- don't need to check non-null for created_at because it's non-null by definition.
-                    GROUP BY c.cntrb_id, c.created_at, c.repo_id, c.login, c.action, c.rank, con.cntrb_company
+                    GROUP BY c.cntrb_id, c.created_at, c.repo_id, c.login, c.action, c.rank, con.cntrb_company, con.cntrb_email, con.cntrb_canonical
                     ORDER BY
                         c.created_at
                     """


### PR DESCRIPTION
### Pull Request Change Description
This pr changes affiliations query to also include information that is in the contributors table. This now includes the GH profile information in the affiliations analysis. 

### Generative AI disclosure
<!-- To learn more about our Generative AI policy and required disclosures, see the `CONTRIBUTING.md` file -->

Please select one option:

- [ ] This contribution was NOT assisted or created by Generative AI tools.
- [x] This contribution was assisted or created by Generative AI tools.


If AI tools were used, please provide details below:
    - What tools were used? claude
    - How were these tools used? Help coming up with the finalized query 
    - Did you review these outputs before submitting this PR? yes, went back and forth in claude ui, testing query in notebook, then made changes in 8knot
