### PR TITLE
Fix GROUP BY mismatch in affiliation_query

### DIFF
--- a/8Knot/queries/affiliation_query.py
+++ b/8Knot/queries/affiliation_query.py
@@ -35,7 +35,7 @@ def affiliation_query(self, repos):
 
     query_string = f"""
                     SELECT
-                        left(ca.cntrb_id::text, 15) as cntrb_id, -- first 15 characters of the uuid
+                        left(c.cntrb_id::text, 15) as cntrb_id, -- first 15 characters of the uuid
                         timezone('utc', c.created_at) AS created_at,
                         c.repo_id,
                         c.login,


### PR DESCRIPTION
Use c.cntrb_id instead of ca.cntrb_id in SELECT to match the GROUP BY clause.

### Pull Request Change Description
<!-- Please give a thorough descriptions of the intended changes made by this PR -->

### Generative AI disclosure
<!-- To learn more about our Generative AI policy and required disclosures, see the `CONTRIBUTING.md` file -->

Please select one option:

- [ ] This contribution was NOT assisted or created by Generative AI tools.
- [ ] This contribution was assisted or created by Generative AI tools.


If AI tools were used, please provide details below:
    - What tools were used? <!-- gemini / chatgpt / claude .etc -->
    - How were these tools used? <!-- initial draft of the code / code review / writing tests .etc -->
    - Did you review these outputs before submitting this PR? <!-- No / Yes and I made these fixes... -->
