### PR TITLE
Redis flush

### DIFF
--- a/8Knot/cache_manager/db_init.py
+++ b/8Knot/cache_manager/db_init.py
@@ -61,7 +61,9 @@ Generally, 'int' is good for integers,
 
 import logging
 import sys
+import os
 import psycopg2 as pg
+import redis
 import time
 
 # doesn't use relative import syntax "import .cx_common" because
@@ -394,6 +396,35 @@ def _create_application_tables() -> None:
     logging.warning("ALL TABLES COMMITTED SUCCESSFULLY")
 
 
+def _flush_redis_broker() -> None:
+    """
+    Flush the Redis broker so it stays in sync with postgres-cache.
+
+    postgres-cache uses UNLOGGED tables, so all cached data is lost on
+    restart. If Redis still holds stale Celery task messages or results
+    from a previous run, workers pick them up and poll for data that no
+    longer exists, causing deadlocks. Flushing here guarantees a clean
+    broker state every time the cache is (re)initialized.
+    """
+    broker_host = os.getenv("REDIS_SERVICE_HOST", "redis-broker")
+    broker_port = int(os.getenv("REDIS_SERVICE_PORT", "6379"))
+    broker_password = os.getenv("REDIS_PASSWORD", "")
+
+    users_host = os.getenv("REDIS_SERVICE_USERS_HOST", "redis-users")
+    users_port = int(os.getenv("REDIS_SERVICE_USERS_PORT", "6379"))
+
+    for name, host, port in [
+        ("redis-broker", broker_host, broker_port),
+        ("redis-users", users_host, users_port),
+    ]:
+        try:
+            r = redis.StrictRedis(host=host, port=port, password=broker_password)
+            r.flushall()
+            logging.warning(f"db_init: FLUSHED {name} ({host}:{port})")
+        except Exception as e:
+            logging.warning(f"db_init: could not flush {name}: {e}")
+
+
 def db_init() -> int:
     try:
         # don't need to check return values- errors propogate as exceptions,
@@ -404,6 +435,9 @@ def db_init() -> int:
 
         # add tables to augur_cache db if they don't already exist.
         _create_application_tables()
+
+        # flush redis so broker state matches the fresh postgres-cache.
+        _flush_redis_broker()
 
         logging.warning("db_init: POSTGRES CACHE SUCCESSFULLY INITIALIZED")
 

--- a/8Knot/cache_manager/db_init.py
+++ b/8Knot/cache_manager/db_init.py
@@ -407,11 +407,11 @@ def _flush_redis_broker() -> None:
     broker state every time the cache is (re)initialized.
     """
     broker_host = os.getenv("REDIS_SERVICE_HOST", "redis-broker")
-    broker_port = int(os.getenv("REDIS_SERVICE_PORT", "6379"))
+    broker_port = int(os.getenv("REDIS_SERVICE_PORT") or "6379")
     broker_password = os.getenv("REDIS_PASSWORD", "")
 
     users_host = os.getenv("REDIS_SERVICE_USERS_HOST", "redis-users")
-    users_port = int(os.getenv("REDIS_SERVICE_USERS_PORT", "6379"))
+    users_port = int(os.getenv("REDIS_SERVICE_USERS_PORT") or "6379")
 
     for name, host, port in [
         ("redis-broker", broker_host, broker_port),

--- a/8Knot/cache_manager/db_init.py
+++ b/8Knot/cache_manager/db_init.py
@@ -66,6 +66,17 @@ import psycopg2 as pg
 import redis
 import time
 
+
+def _env_int(var: str, default: int) -> int:
+    """Return an env var as int, falling back to *default* on missing, empty, or non-numeric values."""
+    raw = os.getenv(var, "")
+    try:
+        return int(raw) if raw else default
+    except ValueError:
+        logging.warning(f"db_init: ignoring non-numeric {var}={raw!r}, using {default}")
+        return default
+
+
 # doesn't use relative import syntax "import .cx_common" because
 # cx_common is a neighbor of script, thus is available in PYTHON_PATH
 from cx_common import init_cx_string, cache_cx_string
@@ -407,11 +418,11 @@ def _flush_redis_broker() -> None:
     broker state every time the cache is (re)initialized.
     """
     broker_host = os.getenv("REDIS_SERVICE_HOST", "redis-broker")
-    broker_port = int(os.getenv("REDIS_SERVICE_PORT") or "6379")
+    broker_port = _env_int("REDIS_SERVICE_PORT", 6379)
     broker_password = os.getenv("REDIS_PASSWORD", "")
 
     users_host = os.getenv("REDIS_SERVICE_USERS_HOST", "redis-users")
-    users_port = int(os.getenv("REDIS_SERVICE_USERS_PORT") or "6379")
+    users_port = _env_int("REDIS_SERVICE_USERS_PORT", 6379)
 
     for name, host, port in [
         ("redis-broker", broker_host, broker_port),

--- a/8Knot/cache_manager/db_init.py
+++ b/8Knot/cache_manager/db_init.py
@@ -68,7 +68,27 @@ import time
 
 
 def _env_int(var: str, default: int) -> int:
-    """Return an env var as int, falling back to *default* on missing, empty, or non-numeric values."""
+    """Parse an environment variable as an integer with safe fallback.
+
+    Wraps int() conversion in a try/except so that misconfigured
+    environment variables never crash the application on startup.
+
+    Behavior:
+        - Env var is unset or empty  -> returns *default*.
+        - Env var is a valid integer -> returns int(value).
+        - Env var is non-numeric (e.g. "ABCD") -> the string is truthy
+          so int() is attempted, raises ValueError, which is caught;
+          logs a warning so the misconfiguration is visible and falls
+          back to *default*.
+
+    Args:
+        var:     Name of the environment variable.
+        default: Value returned when the variable is absent, empty,
+                 or cannot be parsed as an integer.
+
+    Returns:
+        The parsed integer, or *default* on any failure.
+    """
     raw = os.getenv(var, "")
     try:
         return int(raw) if raw else default

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,10 @@ services:
     depends_on:
       postgres-cache:
         condition: service_healthy  # to ensure that postgres is indeed initialized before this starts
+      redis-broker:
+        condition: service_started
+      redis-users:
+        condition: service_started
     env_file:
       - .env
     # sometimes, postgres-cache isn't spun up before this starts.


### PR DESCRIPTION
This PR resolves #1150. 

The pr flushes redis at start getting in sync with postgres start, since its cache starts fresh.

### Pull Request Change Description
<!-- Please give a thorough descriptions of the intended changes made by this PR -->

### Generative AI disclosure
<!-- To learn more about our Generative AI policy and required disclosures, see the `CONTRIBUTING.md` file -->

Please select one option:

- [ ] This contribution was NOT assisted or created by Generative AI tools.
- [x] This contribution was assisted or created by Generative AI tools.


If AI tools were used, please provide details below:
    - What tools were used? <!-- gemini / chatgpt / claude .etc --> Claude. 
    - How were these tools used? <!-- initial draft of the code / code review / writing tests .etc --> Initial draft, brainstorming, prototype.
    - Did you review these outputs before submitting this PR? <!-- No / Yes and I made these fixes... --> Yes.
