### PR TITLE
Increase concurrency and change query order to reduce query bottleneck on local instances

### DIFF
--- a/8Knot/pages/index/index_callbacks.py
+++ b/8Knot/pages/index/index_callbacks.py
@@ -37,7 +37,9 @@ from .search_utils import fuzzy_search
 from .search_utils import clean_repo_name
 
 # list of queries to be run (includes codebase page queries for heatmaps)
-QUERIES = [iq, cq, cnq, prq, aq, iaq, praq, prr, cpfq, rfq, prfq, rlq, pvq, rrq, osq, riq]
+# affiliation_query is last because its 3-way JOIN + GROUP BY is the slowest query;
+# keeping it at the end lets the faster queries finish without being blocked.
+QUERIES = [iq, cq, cnq, prq, iaq, praq, prr, cpfq, rfq, prfq, rlq, pvq, rrq, osq, riq, aq]
 
 
 # check if login has been enabled in config

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
         ":8080",
         "app:server",
         "--workers",
-        "4",
+        "1",
         "--threads",
         "2",
         "--timeout",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
         ":8080",
         "app:server",
         "--workers",
-        "1",
+        "4",
         "--threads",
         "2",
         "--timeout",
@@ -67,7 +67,7 @@ services:
     build:
       context: .
       dockerfile: ./docker/Dockerfile
-    command: ["celery", "-A", "app:celery_app", "worker", "--loglevel=INFO", "--concurrency=1", "--time-limit=700", "--soft-time-limit=630"]
+    command: ["celery", "-A", "app:celery_app", "worker", "--loglevel=INFO", "--concurrency=8", "--time-limit=700", "--soft-time-limit=630"]
     depends_on:
       - redis-cache
       - redis-users

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,7 +89,7 @@ services:
         "--loglevel=INFO",
         "-Q",
         "data",
-        "--concurrency=1",
+        "--concurrency=2",
         "--time-limit=600",
         "--soft-time-limit=540"
       ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,7 +89,7 @@ services:
         "--loglevel=INFO",
         "-Q",
         "data",
-        "--concurrency=2",
+        "--concurrency=8",
         "--time-limit=600",
         "--soft-time-limit=540"
       ]


### PR DESCRIPTION
This PR fixes #1152 

* The Workers-query concurrency is increased to parallelise the queries to avoid being deadlocked by slower and much complex queries like the affiliation q. 
So, the worker-query concurrency is bumped up to 8 to allow for 8 parallel queries to run, allowing for all faster queries to finish without the need to wait for affiliation q. Also this query is placed in the last place, so that it won't have any possibility of really blocking any query of being completed. Also, the sweet spot seems to be 8, as when the concurrency number is too high, there's too many long running queries hitting CollectOSS, which ends up dropping some of them and triggering a 3 min reset. 

* After increasing concurrency on the query's side, it is also necessary to bump up the callback concurrency, as the concurrency = 1, ends up blocking viz callbacks and freezing the page waiting for queries like affiliation to be completed. Once we increase the callback concurrency, any deadlock caused by complex queries is now resolved. Callbacks and viz can run without blocks, and pages get unfrozen, so the user can go to other pages if he wants as well without having to wait for the query or callback to finish. 



### Pull Request Change Description
<!-- Please give a thorough descriptions of the intended changes made by this PR -->

### Generative AI disclosure
<!-- To learn more about our Generative AI policy and required disclosures, see the `CONTRIBUTING.md` file -->

Please select one option:

- [x] This contribution was NOT assisted or created by Generative AI tools.
- [ ] This contribution was assisted or created by Generative AI tools.


If AI tools were used, please provide details below:
    - What tools were used? <!-- gemini / chatgpt / claude .etc -->
    - How were these tools used? <!-- initial draft of the code / code review / writing tests .etc -->
    - Did you review these outputs before submitting this PR? <!-- No / Yes and I made these fixes... -->
