### PR TITLE
Create index for postgres cache tables

### DIFF
--- a/8Knot/cache_manager/db_init.py
+++ b/8Knot/cache_manager/db_init.py
@@ -133,6 +133,42 @@ def _create_application_database() -> None:
     conn.close()
 
 
+_CACHE_TABLES_WITH_REPO_ID = (
+    "commits_query",
+    "issues_query",
+    "prs_query",
+    "affiliation_query",
+    "contributors_query",
+    "issue_assignee_query",
+    "pr_assignee_query",
+    "cntrb_per_file_query",
+    "pr_file_query",
+    "repo_files_query",
+    "repo_languages_query",
+    "package_version_query",
+    "repo_releases_query",
+    "ossf_score_query",
+    "repo_info_query",
+    "pr_response_query",
+)
+
+
+def _create_cache_indexes(cur) -> None:
+    """
+    Indexes for cache reads (retrieve_from_cache) and bookkeeping lookups
+    (get_uncached). UNLOGGED tables do not get indexes automatically.
+    """
+    for table in _CACHE_TABLES_WITH_REPO_ID:
+        cur.execute(f"CREATE INDEX IF NOT EXISTS {table}_repo_id_idx ON {table} (repo_id)")
+    cur.execute(
+        """
+        CREATE INDEX IF NOT EXISTS cache_bookkeeping_cache_func_repo_id_idx
+        ON cache_bookkeeping (cache_func, repo_id)
+        """
+    )
+    logging.warning("CREATED CACHE INDEXES")
+
+
 def _create_application_tables() -> None:
     """
     Creates tables for cached data in 'augur_cache' database.
@@ -387,6 +423,8 @@ def _create_application_tables() -> None:
             """
         )
         logging.warning("CREATED cache_bookkeeping TABLE")
+
+        _create_cache_indexes(cur)
 
         # commit changes, all-or-nothing.
         conn.commit()

--- a/8Knot/cache_manager/db_init.py
+++ b/8Knot/cache_manager/db_init.py
@@ -133,32 +133,25 @@ def _create_application_database() -> None:
     conn.close()
 
 
-_CACHE_TABLES_WITH_REPO_ID = (
-    "commits_query",
-    "issues_query",
-    "prs_query",
-    "affiliation_query",
-    "contributors_query",
-    "issue_assignee_query",
-    "pr_assignee_query",
-    "cntrb_per_file_query",
-    "pr_file_query",
-    "repo_files_query",
-    "repo_languages_query",
-    "package_version_query",
-    "repo_releases_query",
-    "ossf_score_query",
-    "repo_info_query",
-    "pr_response_query",
-)
-
-
 def _create_cache_indexes(cur) -> None:
     """
     Indexes for cache reads (retrieve_from_cache) and bookkeeping lookups
     (get_uncached). UNLOGGED tables do not get indexes automatically.
+
+    Discovers tables with a repo_id column at runtime so new cache tables
+    get indexed automatically without maintaining a hardcoded list.
     """
-    for table in _CACHE_TABLES_WITH_REPO_ID:
+    cur.execute(
+        """
+        SELECT table_name
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND column_name = 'repo_id'
+          AND table_name != 'cache_bookkeeping'
+        ORDER BY table_name
+        """
+    )
+    for (table,) in cur.fetchall():
         cur.execute(f"CREATE INDEX IF NOT EXISTS {table}_repo_id_idx ON {table} (repo_id)")
     cur.execute(
         """


### PR DESCRIPTION
This PR's goal is to create index for every cache table. The reason why being that retrieve_from_cache() executes SELECT * ... without an index, which consequently means a sequential scan for potentially millions of rows. The UNLOGGED tables also don't auto-index. 
The impact, especially on prod and large repos, can be quite significant, in terms of complexity, it goes from O(n) to O(log n), so this could represent 10-100x faster on retrieval. 


### Pull Request Change Description
<!-- Please give a thorough descriptions of the intended changes made by this PR -->

### Generative AI disclosure
<!-- To learn more about our Generative AI policy and required disclosures, see the `CONTRIBUTING.md` file -->

Please select one option:

- [ ] This contribution was NOT assisted or created by Generative AI tools.
- [x] This contribution was assisted or created by Generative AI tools.


If AI tools were used, please provide details below:
    - What tools were used? <!-- gemini / chatgpt / claude .etc --> Claude
    - How were these tools used? <!-- initial draft of the code / code review / writing tests .etc --> Working on breaking down concepts and understanding layers of cache system. Initial draft.
    - Did you review these outputs before submitting this PR? <!-- No / Yes and I made these fixes... --> Yes.
