### PR TITLE
rewrite affiliation_query with CTE to eliminate alias JOIN explosion

### DIFF
--- a/8Knot/queries/affiliation_query.py
+++ b/8Knot/queries/affiliation_query.py
@@ -37,8 +37,6 @@ def affiliation_query(self, repos):
                     WITH contributor_emails AS (
                         -- pre-aggregate one email list per contributor so the main query
                         -- avoids the alias JOIN explosion (O(N*A) -> O(N)).
-                        -- LEFT JOIN preserves contributors who have no alias entries,
-                        -- which the previous INNER JOIN silently dropped.
                         SELECT
                             con.cntrb_id,
                             con.cntrb_company,
@@ -50,11 +48,11 @@ def affiliation_query(self, repos):
                                 ''
                             ) AS email_list
                         FROM contributors con
-                        LEFT JOIN contributors_aliases ca ON con.cntrb_id = ca.cntrb_id,
+                        JOIN contributors_aliases ca ON con.cntrb_id = ca.cntrb_id,
                         LATERAL unnest(ARRAY[ca.alias_email, con.cntrb_email, con.cntrb_canonical]) AS e
                         GROUP BY con.cntrb_id, con.cntrb_company
                     )
-                    SELECT
+                    SELECT DISTINCT
                         left(c.cntrb_id::text, 15) AS cntrb_id,
                         timezone('utc', c.created_at) AS created_at,
                         c.repo_id,
@@ -67,7 +65,7 @@ def affiliation_query(self, repos):
                     WHERE
                         c.repo_id IN %s
                         AND timezone('utc', c.created_at) < now()
-                    ORDER BY c.created_at
+                    ORDER BY created_at
                     """
 
     # used for caching

--- a/8Knot/queries/affiliation_query.py
+++ b/8Knot/queries/affiliation_query.py
@@ -34,36 +34,37 @@ def affiliation_query(self, repos):
         return None
 
     query_string = f"""
+                    WITH contributor_emails AS (
+                        -- pre-aggregate one email list per contributor so the main query
+                        -- avoids the alias JOIN explosion (O(N*A) -> O(N)).
+                        -- LEFT JOIN preserves contributors who have no alias entries,
+                        -- which the previous INNER JOIN silently dropped.
+                        SELECT
+                            con.cntrb_id,
+                            con.cntrb_company,
+                            array_to_string(
+                                array_agg(DISTINCT e) FILTER (WHERE e IS NOT NULL AND e != ''),
+                                ' , '
+                            ) AS email_list
+                        FROM contributors con
+                        LEFT JOIN contributors_aliases ca ON con.cntrb_id = ca.cntrb_id,
+                        LATERAL unnest(ARRAY[ca.alias_email, con.cntrb_email, con.cntrb_canonical]) AS e
+                        GROUP BY con.cntrb_id, con.cntrb_company
+                    )
                     SELECT
-                        left(c.cntrb_id::text, 15) as cntrb_id, -- first 15 characters of the uuid
+                        left(c.cntrb_id::text, 15) AS cntrb_id,
                         timezone('utc', c.created_at) AS created_at,
                         c.repo_id,
                         c.login,
                         c.action,
-                        con.cntrb_company,
-                        array_to_string(
-                            ARRAY(
-                                SELECT DISTINCT e
-                                FROM unnest(
-                                    array_agg(ca.alias_email) ||
-                                    ARRAY[con.cntrb_email, con.cntrb_canonical]
-                                ) AS e
-                                WHERE e IS NOT NULL AND e != ''
-                            ), ' , '
-                        ) AS email_list
-                    FROM
-                        explorer_contributor_actions c
-                    JOIN contributors_aliases ca
-                        ON c.cntrb_id = ca.cntrb_id
-                    JOIN contributors con
-                        ON c.cntrb_id = con.cntrb_id
+                        ce.cntrb_company,
+                        ce.email_list
+                    FROM explorer_contributor_actions c
+                    JOIN contributor_emails ce ON c.cntrb_id = ce.cntrb_id
                     WHERE
-                        c.repo_id in %s
-                        and timezone('utc', c.created_at) < now() -- created_at is a timestamptz value
-                        -- don't need to check non-null for created_at because it's non-null by definition.
-                    GROUP BY c.cntrb_id, c.created_at, c.repo_id, c.login, c.action, con.cntrb_company, con.cntrb_email, con.cntrb_canonical
-                    ORDER BY
-                        c.created_at
+                        c.repo_id IN %s
+                        AND timezone('utc', c.created_at) < now()
+                    ORDER BY c.created_at
                     """
 
     # used for caching

--- a/8Knot/queries/affiliation_query.py
+++ b/8Knot/queries/affiliation_query.py
@@ -42,9 +42,12 @@ def affiliation_query(self, repos):
                         SELECT
                             con.cntrb_id,
                             con.cntrb_company,
-                            array_to_string(
-                                array_agg(DISTINCT e) FILTER (WHERE e IS NOT NULL AND e != ''),
-                                ' , '
+                            COALESCE(
+                                array_to_string(
+                                    array_agg(DISTINCT e) FILTER (WHERE e IS NOT NULL AND e != ''),
+                                    ' , '
+                                ),
+                                ''
                             ) AS email_list
                         FROM contributors con
                         LEFT JOIN contributors_aliases ca ON con.cntrb_id = ca.cntrb_id,


### PR DESCRIPTION
This PR resolves #1159 

The main problem of the affiliation q, is the join of contributor aliases which multiply every action row by the number of aliases, therefore, very costly and slow, especially for large orgs/repos with millions of rows, where contributors can have multiple aliases. The solution is basically replacing the GROUP BY and correlated subquery with a pre-aggregation of the email list per contributor and so avoiding the alias join explosion.


### Pull Request Change Description
<!-- Please give a thorough descriptions of the intended changes made by this PR -->

### Generative AI disclosure
<!-- To learn more about our Generative AI policy and required disclosures, see the `CONTRIBUTING.md` file -->

Please select one option:

- [ ] This contribution was NOT assisted or created by Generative AI tools.
- [x] This contribution was assisted or created by Generative AI tools.


If AI tools were used, please provide details below:
    - What tools were used? <!-- gemini / chatgpt / claude .etc --> Claude
    - How were these tools used? <!-- initial draft of the code / code review / writing tests .etc --> Initial draft.
    - Did you review these outputs before submitting this PR? <!-- No / Yes and I made these fixes... --> Yes.
