### PR TITLE
Enable 8Knot to be flexible with what schema it uses

### DIFF
--- a/8Knot/cache_manager/cx_common.py
+++ b/8Knot/cache_manager/cx_common.py
@@ -26,7 +26,7 @@ env_host = os.getenv("CACHE_HOST", "postgres-cache")
 env_user = os.getenv("CACHE_USER", "postgres")
 env_password = os.getenv("POSTGRES_PASSWORD", "password")
 env_port = os.getenv("CACHE_PORT", "5432")
-env_schema = os.getenv("CACHE_SCHEMA", "augur_data")
+env_schema = os.getenv("CACHE_SCHEMA", env_augur_schema)
 
 
 # purely initial startup string

--- a/8Knot/pages/home/visualizations/issue_metrics.py
+++ b/8Knot/pages/home/visualizations/issue_metrics.py
@@ -139,8 +139,8 @@ def avg_closed_issue_age(repolist):
         select
             avg(now() - i.created_at) as difference
         from
-            augur_data.issues i,
-            augur_data.repo r
+            issues i,
+            repo r
         where
             r.repo_id in ({str(repolist)[1:-1]})
             and i.repo_id = r.repo_id

--- a/8Knot/queries/cntrb_per_file_query.py
+++ b/8Knot/queries/cntrb_per_file_query.py
@@ -35,7 +35,7 @@ def cntrb_per_file_query(self, repos):
                     cntrb_ids,
                     reviewer_ids
                 FROM
-                    augur_data.explorer_cntrb_per_file
+                    explorer_cntrb_per_file
                 WHERE
                     repo_id in %s
                 """

--- a/8Knot/queries/pr_files_query.py
+++ b/8Knot/queries/pr_files_query.py
@@ -34,7 +34,7 @@ def pr_file_query(self, repos):
                         pull_request_id AS pull_request,
                         repo_id
                     FROM
-                        augur_data.explorer_pr_files
+                        explorer_pr_files
                     WHERE
                         repo_id IN %s
                 """

--- a/8Knot/queries/repo_files_query.py
+++ b/8Knot/queries/repo_files_query.py
@@ -44,7 +44,7 @@ def repo_files_query(self, repos):
                         file_path,
                         file_name
                     FROM
-                        augur_data.explorer_repo_files
+                        explorer_repo_files
                     WHERE
                         id IN %s
                         AND repo_name IS NOT NULL

--- a/docs/materialized_views/explorer_cntrb_per_file.sql
+++ b/docs/materialized_views/explorer_cntrb_per_file.sql
@@ -5,13 +5,13 @@ SELECT
     string_agg(DISTINCT CAST(pr.pr_augur_contributor_id AS varchar(15)), ',') AS cntrb_ids,
     string_agg(DISTINCT CAST(prr.cntrb_id AS varchar(15)), ',') AS reviewer_ids
 FROM
-    augur_data.pull_requests pr
+    pull_requests pr
 INNER JOIN
-    augur_data.pull_request_files prf
+    pull_request_files prf
 ON
     pr.pull_request_id = prf.pull_request_id
 LEFT OUTER JOIN
-    augur_data.pull_request_reviews prr
+    pull_request_reviews prr
 ON
     pr.pull_request_id = prr.pull_request_id
 GROUP BY prf.pr_file_path, pr.repo_id

--- a/docs/materialized_views/explorer_pr_files.sql
+++ b/docs/materialized_views/explorer_pr_files.sql
@@ -4,8 +4,8 @@ SELECT
     pr.pull_request_id AS pull_request_id,
     pr.repo_id as repo_id
 FROM
-    augur_data.pull_requests pr
+    pull_requests pr
 INNER JOIN
-    augur_data.pull_request_files prf
+    pull_request_files prf
 ON
     pr.pull_request_id = prf.pull_request_id


### PR DESCRIPTION
### Pull Request Change Description
work in progress PR for fixing #1155 and enabling 8Knot to keep working with data collection instances *both* before and after the CollectOSS fork.

This PR supersedes/replaces (and cherry picks small parts from) #1119 

Still need to:
- [ ] identify all the uses of hard-coded schemas in queries
- [ ] ensure the query paths for both the main DB and the cache DB are being set correctly (look for the new collectoss schema name first, then the legacy one)

### Generative AI disclosure
<!-- To learn more about our Generative AI policy and required disclosures, see the `CONTRIBUTING.md` file -->

Please select one option:

- [X] This contribution was NOT assisted or created by Generative AI tools.
- [ ] This contribution was assisted or created by Generative AI tools.
