### PR TITLE
Add conventional commits breakdown visualization

### DIFF
--- a/8Knot/cache_manager/db_init.py
+++ b/8Knot/cache_manager/db_init.py
@@ -149,6 +149,21 @@ def _create_application_tables() -> None:
     with conn.cursor() as cur:
         # create tables if they don't already exist.
         # TODO: id->repo_id, commits->commit_id
+        cur.execute("SELECT to_regclass('commits_query') IS NOT NULL")
+        commits_query_exists = cur.fetchone()[0]
+        cur.execute(
+            """
+            SELECT EXISTS (
+                SELECT 1
+                FROM information_schema.columns
+                WHERE table_name = 'commits_query'
+                    AND column_name = 'commit_message'
+            )
+            """
+        )
+        commits_query_has_commit_message = cur.fetchone()[0]
+        refresh_commits_query_cache = commits_query_exists and not commits_query_has_commit_message
+
         cur.execute(
             """
             CREATE UNLOGGED TABLE IF NOT EXISTS commits_query(
@@ -157,7 +172,14 @@ def _create_application_tables() -> None:
                 author_email text,
                 author_date text,
                 author_timestamp text,
-                committer_timestamp text)
+                committer_timestamp text,
+                commit_message text)
+            """
+        )
+        cur.execute(
+            """
+            ALTER TABLE commits_query
+            ADD COLUMN IF NOT EXISTS commit_message text
             """
         )
         logging.warning("CREATED commits TABLE")
@@ -387,6 +409,11 @@ def _create_application_tables() -> None:
             """
         )
         logging.warning("CREATED cache_bookkeeping TABLE")
+
+        if refresh_commits_query_cache:
+            cur.execute("DELETE FROM commits_query")
+            cur.execute("DELETE FROM cache_bookkeeping WHERE cache_func = 'commits_query'")
+            logging.warning("INVALIDATED commits_query CACHE TO BACKFILL commit_message")
 
         # commit changes, all-or-nothing.
         conn.commit()

--- a/8Knot/pages/contributions/contributions.py
+++ b/8Knot/pages/contributions/contributions.py
@@ -5,6 +5,7 @@ import warnings
 
 # import the visualization cards
 from .visualizations.commits_over_time import gc_commits_over_time
+from .visualizations.conventional_commits import gc_conventional_commits
 from .visualizations.issues_over_time import gc_issues_over_time
 from .visualizations.issue_staleness import gc_issue_staleness
 from .visualizations.pr_staleness import gc_pr_staleness
@@ -25,6 +26,10 @@ layout = dbc.Container(
     [
         dbc.Row(
             dbc.Col(gc_commits_over_time, xl=10),
+            className="visualization-row",
+        ),
+        dbc.Row(
+            dbc.Col(gc_conventional_commits, xl=10),
             className="visualization-row",
         ),
         dbc.Row(

--- a/8Knot/pages/contributions/visualizations/conventional_commits.py
+++ b/8Knot/pages/contributions/visualizations/conventional_commits.py
@@ -1,0 +1,183 @@
+import logging
+import re
+import time
+
+import cache_manager.cache_facade as cf
+import dash_bootstrap_components as dbc
+import pandas as pd
+import plotly.express as px
+from components.visualization import VisualizationAIO
+from dash import callback
+from dash.dependencies import Input, Output
+from pages.utils.graph_utils import baby_blue, get_graph_time_values
+from pages.utils.job_utils import nodata_graph
+from queries.commits_query import commits_query as cmq
+
+PAGE = "contributions"
+VIZ_ID = "conventional-commits"
+
+CONVENTIONAL_COMMIT_RE = re.compile(r"^(?P<commit_type>[A-Za-z][A-Za-z0-9-]*)(?:\([^)]*\))?!?:")
+CONVENTIONAL_TYPE_ORDER = [
+    "feat",
+    "fix",
+    "docs",
+    "style",
+    "refactor",
+    "perf",
+    "test",
+    "build",
+    "ci",
+    "chore",
+    "revert",
+    "other",
+]
+
+gc_conventional_commits = VisualizationAIO(
+    PAGE,
+    VIZ_ID,
+    title="Conventional Commits Breakdown",
+    graph_info="""
+    Visualizes commits by Conventional Commit type over a user-selected time window.\n
+    Commits that do not match the Conventional Commit prefix format are counted as "other".
+    """,
+    controls=[
+        dbc.Label(
+            "Date Interval:",
+            html_for=f"date-interval-{PAGE}-{VIZ_ID}",
+            width={"size": "auto"},
+        ),
+        dbc.Col(
+            dbc.RadioItems(
+                id=f"date-interval-{PAGE}-{VIZ_ID}",
+                options=[
+                    {
+                        "label": "Day",
+                        "value": "D",
+                    },
+                    {
+                        "label": "Week",
+                        "value": "W",
+                    },
+                    {"label": "Month", "value": "M"},
+                    {"label": "Year", "value": "Y"},
+                ],
+                value="M",
+                inline=True,
+                className="custom-radio-buttons",
+            ),
+            className="me-2",
+            width=4,
+        ),
+    ],
+    class_name="dark-card",
+    id="conventional-commits",
+)
+
+
+@callback(
+    Output(f"{PAGE}-{VIZ_ID}", "figure"),
+    [
+        Input("repo-choices", "data"),
+        Input(f"date-interval-{PAGE}-{VIZ_ID}", "value"),
+    ],
+    background=True,
+)
+def conventional_commits_graph(repolist, interval):
+    while not_cached := cf.get_uncached(func_name=cmq.__name__, repolist=repolist):
+        logging.warning("CONVENTIONAL_COMMITS_VIZ - WAITING ON DATA")
+        time.sleep(0.5)
+
+    start = time.perf_counter()
+    logging.warning("CONVENTIONAL_COMMITS_VIZ - START")
+
+    df = cf.retrieve_from_cache(
+        tablename=cmq.__name__,
+        repolist=repolist,
+    )
+
+    if df.empty:
+        logging.warning("CONVENTIONAL_COMMITS_VIZ - NO DATA AVAILABLE")
+        return nodata_graph
+
+    df_created = process_data(df, interval)
+    if df_created.empty:
+        logging.warning("CONVENTIONAL_COMMITS_VIZ - NO COMMIT MESSAGES AVAILABLE")
+        return nodata_graph
+
+    fig = create_figure(df_created, interval)
+
+    logging.warning(f"CONVENTIONAL_COMMITS_VIZ - END - {time.perf_counter() - start}")
+    return fig
+
+
+def extract_commit_type(commit_message):
+    if pd.isna(commit_message):
+        return "other"
+
+    subject = str(commit_message).splitlines()[0].strip()
+    match = CONVENTIONAL_COMMIT_RE.match(subject)
+    if not match:
+        return "other"
+
+    return match.group("commit_type").lower()
+
+
+def process_data(df: pd.DataFrame, interval):
+    df = df.copy()
+    if "commit_message" not in df.columns:
+        df["commit_message"] = None
+
+    df["author_date"] = pd.to_datetime(df["author_date"], utc=True)
+    df["commit_type"] = df["commit_message"].apply(extract_commit_type)
+
+    period_slice = None
+    if interval == "W":
+        period_slice = 10
+
+    df_created = (
+        df.groupby([df.author_date.dt.to_period(interval), "commit_type"])["commit_hash"]
+        .nunique()
+        .reset_index()
+        .rename(columns={"author_date": "Date", "commit_hash": "commits"})
+    )
+    df_created["Date"] = pd.to_datetime(df_created["Date"].astype(str).str[:period_slice])
+
+    return df_created.sort_values(["Date", "commit_type"])
+
+
+def create_figure(df_created: pd.DataFrame, interval):
+    x_r, x_name, hover, period = get_graph_time_values(interval)
+
+    fig = px.bar(
+        df_created,
+        x="Date",
+        y="commits",
+        color="commit_type",
+        range_x=x_r,
+        labels={
+            "Date": x_name,
+            "commits": "Commits",
+            "commit_type": "Commit Type",
+        },
+        category_orders={"commit_type": CONVENTIONAL_TYPE_ORDER},
+        color_discrete_sequence=baby_blue,
+    )
+    fig.update_traces(hovertemplate=hover + "<br>Type: %{fullData.name}<br>Commits: %{y}<br>")
+    fig.update_xaxes(
+        showgrid=True,
+        ticklabelmode="period",
+        dtick=period,
+        rangeslider_yaxis_rangemode="match",
+        range=x_r,
+    )
+    fig.update_layout(
+        barmode="stack",
+        xaxis_title=x_name,
+        yaxis_title="Number of Commits",
+        margin_b=40,
+        margin_r=20,
+        font=dict(size=14),
+        legend_title_text="Commit Type",
+    )
+
+    return fig

--- a/8Knot/queries/commits_query.py
+++ b/8Knot/queries/commits_query.py
@@ -40,12 +40,16 @@ def commits_query(self, repos):
                         c.cmt_author_date AS author_date,
                         -- all timestamptz's are coerced to utc from their origin timezones.
                         timezone('utc', c.cmt_author_timestamp) AS author_timestamp,
-                        timezone('utc', c.cmt_committer_timestamp) AS committer_timestamp
+                        timezone('utc', c.cmt_committer_timestamp) AS committer_timestamp,
+                        cm.cmt_msg AS commit_message
 
                     FROM
                         repo r
                     JOIN commits c
                         ON r.repo_id = c.repo_id
+                    LEFT JOIN commit_messages cm
+                        ON r.repo_id = cm.repo_id
+                        AND c.cmt_commit_hash = cm.cmt_hash
                     WHERE
                         c.repo_id in %s
                         and timezone('utc', c.cmt_author_timestamp) < now()


### PR DESCRIPTION
Closes #1000.

## Summary
- adds `commit_messages` to the cached commits query so commit subjects are available for visualization
- adds a conditional cache refresh for legacy `commits_query` caches that existed before `commit_message`
- adds a Contributions page stacked bar chart grouping commits by Conventional Commit type, with nonmatching messages counted as `other`

## Validation
- `.venv/bin/python -m black --line-length=120 8Knot/cache_manager/db_init.py 8Knot/queries/commits_query.py 8Knot/pages/contributions/contributions.py 8Knot/pages/contributions/visualizations/conventional_commits.py` -> unchanged
- `.venv/bin/python -m black --check --line-length=120 8Knot/cache_manager/db_init.py 8Knot/queries/commits_query.py 8Knot/pages/contributions/contributions.py 8Knot/pages/contributions/visualizations/conventional_commits.py` -> passed
- `python3 -m py_compile 8Knot/cache_manager/db_init.py 8Knot/queries/commits_query.py 8Knot/pages/contributions/contributions.py 8Knot/pages/contributions/visualizations/conventional_commits.py` -> passed
- `git diff --check` -> passed
- `git diff --cached --check` -> passed before commit
- `gitleaks protect --redact --verbose` -> no leaks found
- `gitleaks protect --staged --redact --verbose` -> no leaks found before commit
- pure processing smoke with stubs -> passed for `feat`, `fix`, `docs`, `other`, unique commit counts, and stacked layout
- cache migration smoke with a fake connection -> passed for legacy invalidation, fresh schema, and current schema branches

## Not run
- DB-backed Dash/Augur rendering was not run locally because local Augur/cache services were not available.
- `uv pip install -e .` was blocked by the repository's flat-layout package discovery (`docker`, `openshift`); dependencies were installed manually for the checks above.
