### PR TITLE
Allow 8Knot to be compatible with both legacy and new CollectOSS database schemas

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -2,7 +2,7 @@ AUGUR_DATABASE=augur
 AUGUR_HOST=mock-db
 AUGUR_PASSWORD=augur
 AUGUR_PORT=5432
-AUGUR_SCHEMA=collection_data,augur_data
+AUGUR_SCHEMA=collection_data,data
 AUGUR_USERNAME=augur
 
 DEBUG_8KNOT=True

--- a/.env.sample
+++ b/.env.sample
@@ -2,7 +2,7 @@ AUGUR_DATABASE=augur
 AUGUR_HOST=mock-db
 AUGUR_PASSWORD=augur
 AUGUR_PORT=5432
-AUGUR_SCHEMA=augur_data
+AUGUR_SCHEMA=collection_data,augur_data
 AUGUR_USERNAME=augur
 
 DEBUG_8KNOT=True

--- a/.env.sample
+++ b/.env.sample
@@ -2,7 +2,7 @@ AUGUR_DATABASE=augur
 AUGUR_HOST=mock-db
 AUGUR_PASSWORD=augur
 AUGUR_PORT=5432
-AUGUR_SCHEMA=collection_data,data
+AUGUR_SCHEMA=data,augur_data
 AUGUR_USERNAME=augur
 
 DEBUG_8KNOT=True

--- a/.github/workflows/nightly-dependency-test.yml
+++ b/.github/workflows/nightly-dependency-test.yml
@@ -12,7 +12,7 @@ env:
   AUGUR_HOST: chaoss.tv
   AUGUR_PASSWORD: cableTV99!
   AUGUR_PORT: 5432
-  AUGUR_SCHEMA: collection_data,data
+  AUGUR_SCHEMA: data,augur_data
   AUGUR_USERNAME: coup
   8KNOT_DEBUG: "True"
   NIGHTLY_TEST: "True"
@@ -90,7 +90,7 @@ jobs:
           AUGUR_HOST=chaoss.tv
           AUGUR_PASSWORD=cableTV99!
           AUGUR_PORT=5432
-          AUGUR_SCHEMA=collection_data,data
+          AUGUR_SCHEMA=data,augur_data
           AUGUR_USERNAME=coup
           8KNOT_DEBUG=True
           NIGHTLY_TEST=True

--- a/.github/workflows/nightly-dependency-test.yml
+++ b/.github/workflows/nightly-dependency-test.yml
@@ -12,7 +12,7 @@ env:
   AUGUR_HOST: chaoss.tv
   AUGUR_PASSWORD: cableTV99!
   AUGUR_PORT: 5432
-  AUGUR_SCHEMA: augur_data
+  AUGUR_SCHEMA: collection_data,data
   AUGUR_USERNAME: coup
   8KNOT_DEBUG: "True"
   NIGHTLY_TEST: "True"
@@ -90,7 +90,7 @@ jobs:
           AUGUR_HOST=chaoss.tv
           AUGUR_PASSWORD=cableTV99!
           AUGUR_PORT=5432
-          AUGUR_SCHEMA=augur_data
+          AUGUR_SCHEMA=collection_data,data
           AUGUR_USERNAME=coup
           8KNOT_DEBUG=True
           NIGHTLY_TEST=True

--- a/8Knot/cache_manager/cx_common.py
+++ b/8Knot/cache_manager/cx_common.py
@@ -13,10 +13,11 @@ try:
     env_augur_host = os.environ["AUGUR_HOST"]
     env_augur_port = os.environ["AUGUR_PORT"]
     env_augur_database = os.environ["AUGUR_DATABASE"]
-    env_augur_schema = os.environ["AUGUR_SCHEMA"]
 except KeyError as ke:
     logging.critical(f"AUGUR: Database credentials incomplete: {ke}")
     raise KeyError(ke)
+
+env_augur_schema = os.getenv("AUGUR_SCHEMA", "collection_data,augur_data")
 
 # credentials to access application cache from environment
 env_dbname = os.getenv("CACHE_DB_NAME", "augur_cache")
@@ -26,7 +27,7 @@ env_host = os.getenv("CACHE_HOST", "postgres-cache")
 env_user = os.getenv("CACHE_USER", "postgres")
 env_password = os.getenv("POSTGRES_PASSWORD", "password")
 env_port = os.getenv("CACHE_PORT", "5432")
-env_schema = os.getenv("CACHE_SCHEMA", "augur_data")
+env_schema = os.getenv("CACHE_SCHEMA", "collection_data,augur_data")
 
 
 # purely initial startup string

--- a/8Knot/cache_manager/cx_common.py
+++ b/8Knot/cache_manager/cx_common.py
@@ -17,7 +17,7 @@ except KeyError as ke:
     logging.critical(f"AUGUR: Database credentials incomplete: {ke}")
     raise KeyError(ke)
 
-env_augur_schema = os.getenv("AUGUR_SCHEMA", "collection_data,data")
+env_augur_schema = os.getenv("AUGUR_SCHEMA", "data,augur_data")
 
 # credentials to access application cache from environment
 env_dbname = os.getenv("CACHE_DB_NAME", "augur_cache")
@@ -27,7 +27,7 @@ env_host = os.getenv("CACHE_HOST", "postgres-cache")
 env_user = os.getenv("CACHE_USER", "postgres")
 env_password = os.getenv("POSTGRES_PASSWORD", "password")
 env_port = os.getenv("CACHE_PORT", "5432")
-env_schema = os.getenv("CACHE_SCHEMA", "collection_data,data")
+env_schema = os.getenv("CACHE_SCHEMA", "data,augur_data")
 
 
 # purely initial startup string

--- a/8Knot/cache_manager/cx_common.py
+++ b/8Knot/cache_manager/cx_common.py
@@ -17,7 +17,7 @@ except KeyError as ke:
     logging.critical(f"AUGUR: Database credentials incomplete: {ke}")
     raise KeyError(ke)
 
-env_augur_schema = os.getenv("AUGUR_SCHEMA", "collection_data,augur_data")
+env_augur_schema = os.getenv("AUGUR_SCHEMA", "collection_data,data")
 
 # credentials to access application cache from environment
 env_dbname = os.getenv("CACHE_DB_NAME", "augur_cache")
@@ -27,7 +27,7 @@ env_host = os.getenv("CACHE_HOST", "postgres-cache")
 env_user = os.getenv("CACHE_USER", "postgres")
 env_password = os.getenv("POSTGRES_PASSWORD", "password")
 env_port = os.getenv("CACHE_PORT", "5432")
-env_schema = os.getenv("CACHE_SCHEMA", "collection_data,augur_data")
+env_schema = os.getenv("CACHE_SCHEMA", "collection_data,data")
 
 
 # purely initial startup string

--- a/8Knot/db_manager/augur_manager.py
+++ b/8Knot/db_manager/augur_manager.py
@@ -71,7 +71,7 @@ class AugurManager:
             logging.critical(f"AUGUR: Database credentials incomplete: {ke}")
             raise KeyError(ke)
 
-        self.schema = os.getenv("AUGUR_SCHEMA", "collection_data,augur_data")
+        self.schema = os.getenv("AUGUR_SCHEMA", "collection_data,data")
 
         # oauth endpoints have to be intact to proceed
         if handles_oauth:

--- a/8Knot/db_manager/augur_manager.py
+++ b/8Knot/db_manager/augur_manager.py
@@ -71,7 +71,7 @@ class AugurManager:
             logging.critical(f"AUGUR: Database credentials incomplete: {ke}")
             raise KeyError(ke)
 
-        self.schema = os.getenv("AUGUR_SCHEMA", "collection_data,data")
+        self.schema = os.getenv("AUGUR_SCHEMA", "data,augur_data")
 
         # oauth endpoints have to be intact to proceed
         if handles_oauth:

--- a/8Knot/db_manager/augur_manager.py
+++ b/8Knot/db_manager/augur_manager.py
@@ -67,10 +67,11 @@ class AugurManager:
             self.host = os.environ["AUGUR_HOST"]
             self.port = os.environ["AUGUR_PORT"]
             self.database = os.environ["AUGUR_DATABASE"]
-            self.schema = os.environ["AUGUR_SCHEMA"]
         except KeyError as ke:
             logging.critical(f"AUGUR: Database credentials incomplete: {ke}")
             raise KeyError(ke)
+
+        self.schema = os.getenv("AUGUR_SCHEMA", "collection_data,augur_data")
 
         # oauth endpoints have to be intact to proceed
         if handles_oauth:

--- a/8Knot/pages/home/visualizations/commit_metrics.py
+++ b/8Knot/pages/home/visualizations/commit_metrics.py
@@ -138,8 +138,8 @@ def commit_count(repolist):
             /*commit_hash'es are unique per commit*/
             count(distinct c.cmt_commit_hash) as num_commits
         from
-            augur_data.commits c,
-            augur_data.repo r
+            commits c,
+            repo r
         where
             r.repo_id in ({str(repolist)[1:-1]})
             and c.repo_id = r.repo_id
@@ -181,8 +181,8 @@ def commit_lines_delta(repolist):
                 (select
                     sum(c.cmt_added) as lines_added, sum(c.cmt_removed) as lines_removed
                 from
-                    augur_data.commits c,
-                    augur_data.repo r
+                    commits c,
+                    repo r
                 where
                     r.repo_id in ({str(repolist)[1:-1]})
                     and c.repo_id = r.repo_id
@@ -222,8 +222,8 @@ def files_per_commit(repolist):
                 /*commit_hash'es are unique per commit*/
                 count(*) as num_files
             from
-                augur_data.commits c,
-                augur_data.repo r
+                commits c,
+                repo r
             where
                 r.repo_id in ({str(repolist)[1:-1]})
                 and c.repo_id = r.repo_id

--- a/8Knot/pages/home/visualizations/issue_metrics.py
+++ b/8Knot/pages/home/visualizations/issue_metrics.py
@@ -139,8 +139,8 @@ def avg_closed_issue_age(repolist):
         select
             avg(now() - i.created_at) as difference
         from
-            augur_data.issues i,
-            augur_data.repo r
+            issues i,
+            repo r
         where
             r.repo_id in ({str(repolist)[1:-1]})
             and i.repo_id = r.repo_id
@@ -188,8 +188,8 @@ def avg_open_issue_age(repolist):
         select
             avg(now() - i.created_at) as difference
         from
-            augur_data.issues i,
-            augur_data.repo r
+            issues i,
+            repo r
         where
             r.repo_id in ({str(repolist)[1:-1]})
             and i.repo_id = r.repo_id
@@ -237,8 +237,8 @@ def closed_issue_count(repolist):
         select
             count(distinct i.issue_id) as num_open_issues
         from
-            augur_data.issues i,
-            augur_data.repo r
+            issues i,
+            repo r
         where
             r.repo_id in ({str(repolist)[1:-1]})
             and i.repo_id = r.repo_id
@@ -274,8 +274,8 @@ def open_issue_count(repolist):
         select
             count(distinct i.issue_id) as num_open_issues
         from
-            augur_data.issues i,
-            augur_data.repo r
+            issues i,
+            repo r
         where
             r.repo_id in ({str(repolist)[1:-1]})
             and i.repo_id = r.repo_id

--- a/8Knot/pages/home/visualizations/pr_metrics.py
+++ b/8Knot/pages/home/visualizations/pr_metrics.py
@@ -191,8 +191,8 @@ def pr_count(repolist):
         select
             count(distinct pr.pull_request_id) as num_open_prs
         from
-            augur_data.pull_requests pr,
-            augur_data.repo r
+            pull_requests pr,
+            repo r
         where
             r.repo_id in ({str(repolist)[1:-1]})
             and pr.repo_id = r.repo_id
@@ -228,8 +228,8 @@ def merged_pr_count(repolist):
         select
             count(distinct pr.pull_request_id) as num_open_prs
         from
-            augur_data.pull_requests pr,
-            augur_data.repo r
+            pull_requests pr,
+            repo r
         where
             r.repo_id in ({str(repolist)[1:-1]})
             and pr.repo_id = r.repo_id
@@ -265,8 +265,8 @@ def rejected_pr_count(repolist):
         select
             count(distinct pr.pull_request_id) as num_open_prs
         from
-            augur_data.pull_requests pr,
-            augur_data.repo r
+            pull_requests pr,
+            repo r
         where
             r.repo_id in ({str(repolist)[1:-1]})
             and pr.repo_id = r.repo_id
@@ -303,8 +303,8 @@ def avg_open_pr_age(repolist):
         select
             avg(now() - pr.pr_created_at) as difference
         from
-            augur_data.pull_requests pr,
-            augur_data.repo r
+            pull_requests pr,
+            repo r
         where
             r.repo_id in ({str(repolist)[1:-1]})
             and pr.repo_id = r.repo_id
@@ -352,8 +352,8 @@ def avg_merged_pr_age(repolist):
         select
             avg(pr.pr_merged_at - pr.pr_created_at) as difference
         from
-            augur_data.pull_requests pr,
-            augur_data.repo r
+            pull_requests pr,
+            repo r
         where
             r.repo_id in ({str(repolist)[1:-1]})
             and pr.repo_id = r.repo_id
@@ -408,9 +408,9 @@ def rejected_pr_count(repolist):
             (select
                 count(distinct prmr.msg_id) message_count
             from
-                augur_data.pull_requests pr,
-                augur_data.pull_request_message_ref prmr,
-                augur_data.repo r
+                pull_requests pr,
+                pull_request_message_ref prmr,
+                repo r
             where
                 r.repo_id in ({str(repolist)[1:-1]})
                 and pr.repo_id = r.repo_id

--- a/8Knot/queries/cntrb_per_file_query.py
+++ b/8Knot/queries/cntrb_per_file_query.py
@@ -35,7 +35,7 @@ def cntrb_per_file_query(self, repos):
                     cntrb_ids,
                     reviewer_ids
                 FROM
-                    augur_data.explorer_cntrb_per_file
+                    explorer_cntrb_per_file
                 WHERE
                     repo_id in %s
                 """

--- a/8Knot/queries/pr_files_query.py
+++ b/8Knot/queries/pr_files_query.py
@@ -34,7 +34,7 @@ def pr_file_query(self, repos):
                         pull_request_id AS pull_request,
                         repo_id
                     FROM
-                        augur_data.explorer_pr_files
+                        explorer_pr_files
                     WHERE
                         repo_id IN %s
                 """

--- a/8Knot/queries/repo_files_query.py
+++ b/8Knot/queries/repo_files_query.py
@@ -40,7 +40,7 @@ def repo_files_query(self, repos):
                         file_path,
                         file_name
                     FROM
-                        augur_data.explorer_repo_files
+                        explorer_repo_files
                     WHERE
                         id IN %s
                         AND repo_name IS NOT NULL

--- a/openshift/base/secret-augur.yaml
+++ b/openshift/base/secret-augur.yaml
@@ -10,7 +10,7 @@ stringData:
   AUGUR_HOST: chaoss.tv
   AUGUR_PASSWORD: '!xpk98T6?bK'
   AUGUR_PORT: '5432'
-  AUGUR_SCHEMA: augur_data
+  AUGUR_SCHEMA: collection_data,data
   AUGUR_USERNAME: eightknot
   # fix: invalid env var
   # DEBUG_8KNOT: 'True'

--- a/openshift/base/secret-augur.yaml
+++ b/openshift/base/secret-augur.yaml
@@ -10,7 +10,7 @@ stringData:
   AUGUR_HOST: chaoss.tv
   AUGUR_PASSWORD: '!xpk98T6?bK'
   AUGUR_PORT: '5432'
-  AUGUR_SCHEMA: collection_data,data
+  AUGUR_SCHEMA: data,augur_data
   AUGUR_USERNAME: eightknot
   # fix: invalid env var
   # DEBUG_8KNOT: 'True'


### PR DESCRIPTION
This PR adapts 8knot for the new schema from CollectOSS by adding its schema name into the search path, as the first one to be used, and then defaults to augur_data if it doesn't work.

### Pull Request Change Description
<!-- Please give a thorough descriptions of the intended changes made by this PR -->

### Generative AI disclosure
<!-- To learn more about our Generative AI policy and required disclosures, see the `CONTRIBUTING.md` file -->

Please select one option:

- [ ] This contribution was NOT assisted or created by Generative AI tools.
- [x] This contribution was assisted or created by Generative AI tools.


If AI tools were used, please provide details below:
    - What tools were used? <!-- gemini / chatgpt / claude .etc --> Claude-Opus -4.8
    - How were these tools used? <!-- initial draft of the code / code review / writing tests .etc --> Finding the places to fix for the new schema.
    - Did you review these outputs before submitting this PR? <!-- No / Yes and I made these fixes... --> Yes.
