### PR TITLE
Add maintainers md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,19 @@
+# 8Knot Project Maintainers
+
+The current Maintainers for the 8Knot Project consists of:
+
+| Name | Employer | Responsibilities |
+| ---- | -------- | ---------------- |
+| [Adrian Edwards](https://github.com/MoralCode) | Red Hat | Maintainer |
+| [Cali Dolfi](https://github.com/cdolfi) | Red Hat | Maintainer |
+| [Caio Fonseca](https://github.com/caiosfonseca) | Red Hat | Maintainer |
+
+See [the project Governance](GOVERNANCE.md) for how maintainers are selected and replaced.
+
+## Emeritus Maintainers
+
+The following people have helped by leading and contributing to the 8Knot project, but have reduced their level of involvement, or stepped aside so that others may step up in their place.
+
+| Name | Date of Retirement |
+| ---- | ------------------ |
+| [James Kunstle](https://github.com/jkunstle) | - |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,7 +6,7 @@ The current Maintainers for the 8Knot Project consists of:
 | ---- | -------- | ---------------- |
 | [Adrian Edwards](https://github.com/MoralCode) | Red Hat | Maintainer |
 | [Cali Dolfi](https://github.com/cdolfi) | Red Hat | Maintainer |
-| [Caio Fonseca](https://github.com/caiosfonseca) | Red Hat | Maintainer |
+| [Caio Fonseca](https://github.com/EngCaioFonseca) | Red Hat | Maintainer |
 
 See [the project Governance](GOVERNANCE.md) for how maintainers are selected and replaced.
 


### PR DESCRIPTION
### Pull Request Change Description

Adds a `MAINTAINERS.md` file to the repository root, as requested in issue #1178.

The file follows the format referenced in the issue (CollectOSS project), listing:
- Current maintainers: Adrian Edwards, Cali Dolfi, and Caio Fonseca
- Emeritus maintainer: James Kunstle

Maintainer info was sourced from the existing `docs/AUTHORS.md` file. The file also links to `GOVERNANCE.md` as per the governance doc's own reference to `./MAINTAINERS.md`.

Closes #1178

### Generative AI disclosure

- [x] This contribution was assisted or created by Generative AI tools.

If AI tools were used, please provide details below:
- What tools were used? Kiro (AI-powered dev environment)
- How were these tools used? Initial draft of the file content, sourcing maintainer details from existing repo files
- Did you review these outputs before submitting this PR? Yes