### PR TITLE
update infobox wording for package version visualization

### DIFF
--- a/8Knot/pages/repo_overview/visualizations/package_version.py
+++ b/8Knot/pages/repo_overview/visualizations/package_version.py
@@ -23,8 +23,9 @@ gc_package_version = VisualizationAIO(
     VIZ_ID,
     title="Package Version Updates",
     graph_info="""
-        Visualizes for each packaged dependency, if it is up to date and if not if it is
-        less than 6 months out, between 6 months and a year, or greater than a year.
+        Shows the version freshness of each packaged dependency in the repository.
+        Dependencies are grouped by how outdated they are: up to date, less than 6 months
+        behind, between 6 months and 1 year behind, or more than 1 year behind.
     """,
     controls=[],
     class_name="dark-card",


### PR DESCRIPTION
### Pull Request Change Description

Improves the `graph_info` description for the "Package Version Updates" visualization for clarity and readability.

**Before:**
> Visualizes for each packaged dependency, if it is up to date and if not if it is less than 6 months out, between 6 months and a year, or greater than a year.

**After:**
> Shows the version freshness of each packaged dependency in the repository. Dependencies are grouped by how outdated they are: up to date, less than 6 months behind, between 6 months and 1 year behind, or more than 1 year behind.

Closes #1142

### Generative AI disclosure

- [x] This contribution was assisted or created by Generative AI tools.
  - What tools were used? Kiro (AI-powered dev environment)
  - How were these tools used? Suggested improved wording for the graph description
  - Did you review these outputs before submitting this PR? Yes
