### PR TITLE
Add OOM troubleshooting note to README

### DIFF
--- a/.wordlist-md
+++ b/.wordlist-md
@@ -123,3 +123,4 @@ CoCC
 CoC
 Inclusivity
 discoverable
+OOM

--- a/README.md
+++ b/README.md
@@ -324,6 +324,10 @@ guaranteeing that there are (2 \* #CPUs = 12) available processing celery thread
 docker compose up --build --scale worker-query=2 --scale worker-callback=2
 ```
 
+> **Out of Memory (OOM) issues:** If your local instance is running out of memory, try reducing the number of concurrent workers
+> by lowering the `--concurrency` value in `docker-compose.yml` for the `worker-callback` and `worker-query` services.
+> The default concurrency is 8; reducing it to 2 or 4 can significantly reduce memory usage at the cost of slower data loading.
+
 To stop the application:
 
 ```bash
@@ -360,6 +364,10 @@ guaranteeing that there are (2 \* #CPUs = 12) available processing celery thread
 ```bash
 podman compose up --build --scale worker-query=2 --scale worker-callback=2
 ```
+
+> **Out of Memory (OOM) issues:** If your local instance is running out of memory, try reducing the number of concurrent workers
+> by lowering the `--concurrency` value in `docker-compose.yml` for the `worker-callback` and `worker-query` services.
+> The default concurrency is 8; reducing it to 2 or 4 can significantly reduce memory usage at the cost of slower data loading.
 
 To stop the application:
 

--- a/README.md
+++ b/README.md
@@ -365,10 +365,6 @@ guaranteeing that there are (2 \* #CPUs = 12) available processing celery thread
 podman compose up --build --scale worker-query=2 --scale worker-callback=2
 ```
 
-> **Out of Memory (OOM) issues:** If your local instance is running out of memory, try reducing the number of concurrent workers
-> by lowering the `--concurrency` value in `docker-compose.yml` for the `worker-callback` and `worker-query` services.
-> The default concurrency is 8; reducing it to 2 or 4 can significantly reduce memory usage at the cost of slower data loading.
-
 To stop the application:
 
 ```bash


### PR DESCRIPTION
### Pull Request Change Description

Adds an Out of Memory (OOM) troubleshooting note to the README in both the Docker and Podman deployment sections.

Users who increase the number of concurrent workers to avoid the known deadlock may inadvertently hit memory limits on local machines. The note advises reducing the `--concurrency` value in `docker-compose.yml` for the `worker-callback` and `worker-query` services (default is 8; reducing to 2–4 can significantly lower memory usage).

Closes #1169

### Generative AI disclosure

- [x] This contribution was assisted or created by Generative AI tools.
  - What tools were used? Kiro (AI-powered dev environment)
  - How were these tools used? Suggested placement and wording for the documentation addition
  - Did you review these outputs before submitting this PR? Yes
