### PR TITLE
add .gitattributes to fix python line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Set default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Enforce LF for Python files and shell scripts
+*.py text eol=lf
+*.sh text eol=lf
+
+# Force CRLF for Windows-specific files if any exist
+*.bat text eol=crlf
+*.cmd text eol=crlf


### PR DESCRIPTION
Hey, saw this good first issue and wanted to help out. Added a `.gitattributes` file to enforce LF for Python scripts and prevent the CRLF rewriting issues mentioned in #1061. Let me know if you need any changes!