### PR TITLE
Shareable URL with the right anchor set to each graph view

### DIFF
--- a/8Knot/app.py
+++ b/8Knot/app.py
@@ -51,6 +51,7 @@ augur.multiselect_startup()
 
 """IMPORT AFTER GLOBAL VARIABLES SET"""
 import pages.index.index_callbacks as index_callbacks
+import pages.index.share_callbacks as share_callbacks
 import pages.landing.landing_callbacks as landing_callbacks
 
 # Import testing utilities for enhanced error detection in CI

--- a/8Knot/cache_manager/url_state.py
+++ b/8Knot/cache_manager/url_state.py
@@ -1,0 +1,113 @@
+"""Encode/decode the share-link state payload (versioned JSON -> gzip -> base64url)."""
+
+from __future__ import annotations
+
+import io
+import gzip
+import json
+import base64
+from collections.abc import Callable
+
+CURRENT_VERSION = 1
+
+# The ?state= blob is attacker-controlled. Cap the decompressed size (zip-bomb
+# guard) and the encoded input itself; a legitimate 200-repo payload is < 1 KiB.
+MAX_DECODED_BYTES = 64 * 1024
+MAX_ENCODED_LEN = 16 * 1024
+
+# Caps on payload collections — bounds the work a crafted link can cause.
+_MAX_REPO_IDS = 10_000
+_MAX_ORG_NAMES = 1_000
+
+# Maps an OLD version -> a function upgrading a payload by one version (must
+# bump "v"). decode_state walks this chain, so bumping CURRENT_VERSION does not
+# break previously issued links: they are upgraded in memory on read. Example
+# when introducing v2:  MIGRATIONS = {1: _v1_to_v2}
+MIGRATIONS: dict[int, Callable[[dict], dict]] = {}
+
+
+def _migrate(payload: dict) -> dict | None:
+    """Upgrade a payload to CURRENT_VERSION, or None if no path exists."""
+    v = payload.get("v")
+    while v != CURRENT_VERSION:
+        migrate = MIGRATIONS.get(v)
+        if migrate is None:
+            return None
+        payload = migrate(payload)
+        new_v = payload.get("v")
+        if new_v == v:  # a migration that doesn't advance would loop forever
+            return None
+        v = new_v
+    return payload
+
+
+def encode_state(
+    repo_ids: list[int], org_names: list[str], pathname: str, graph_id: str | None, filters: dict | None = None
+) -> str:
+    payload = {
+        "v": CURRENT_VERSION,
+        "repo_ids": repo_ids,
+        "org_names": org_names,
+        "pathname": pathname,
+        "graph_id": graph_id,
+        "filters": filters or {},
+    }
+    raw = json.dumps(payload, separators=(",", ":")).encode()
+    compressed = gzip.compress(raw, compresslevel=9)
+    return base64.urlsafe_b64encode(compressed).decode().rstrip("=")
+
+
+def _is_valid_shape(p: dict) -> bool:
+    """Type-check every payload field so downstream consumers can trust it.
+
+    Valid JSON can still carry hostile shapes (lists where strings belong,
+    unhashable values) that would raise in downstream lookups. bool is
+    excluded from ints because isinstance(True, int) is True.
+    """
+    if not isinstance(p.get("pathname"), str):
+        return False
+    gid = p.get("graph_id")
+    if gid is not None and not isinstance(gid, str):
+        return False
+    repo_ids = p.get("repo_ids", [])
+    if not isinstance(repo_ids, list) or len(repo_ids) > _MAX_REPO_IDS:
+        return False
+    if not all(isinstance(r, int) and not isinstance(r, bool) for r in repo_ids):
+        return False
+    org_names = p.get("org_names", [])
+    if not isinstance(org_names, list) or len(org_names) > _MAX_ORG_NAMES:
+        return False
+    if not all(isinstance(o, str) for o in org_names):
+        return False
+    if not isinstance(p.get("filters", {}), dict):
+        return False
+    return True
+
+
+def decode_state(encoded: str) -> dict | None:
+    """Decode a ?state= blob into a trusted payload dict, or None if invalid."""
+    try:
+        if not encoded or len(encoded) > MAX_ENCODED_LEN:
+            return None
+
+        padded = encoded + "=" * (-len(encoded) % 4)
+        compressed = base64.urlsafe_b64decode(padded)
+
+        # Bounded read: detect oversize without materializing a bomb.
+        with gzip.GzipFile(fileobj=io.BytesIO(compressed)) as f:
+            raw = f.read(MAX_DECODED_BYTES + 1)
+        if len(raw) > MAX_DECODED_BYTES:
+            return None
+
+        payload = json.loads(raw)
+        if not isinstance(payload, dict):
+            return None
+        if payload.get("v") != CURRENT_VERSION:
+            payload = _migrate(payload)  # old link: upgrade rather than reject
+            if payload is None:
+                return None
+        if not _is_valid_shape(payload):
+            return None
+        return payload
+    except Exception:
+        return None

--- a/8Knot/components/visualization.py
+++ b/8Knot/components/visualization.py
@@ -43,14 +43,24 @@ class VisualizationAIO(dbc.Card):
                             [
                                 dbc.Col(html.H3(title, id=f"graph-title-{page}-{viz_id}", className="card-title")),
                                 dbc.Col(
-                                    dbc.Button(
-                                        "About Graph",
-                                        id={"type": "popover-target", "index": f"{page}-{viz_id}"},
-                                        color="outline-secondary",
-                                        size="sm",
-                                        className="about-graph-button",
-                                    ),
+                                    [
+                                        dbc.Button(
+                                            [html.I(className="fas fa-share-alt me-1"), "Share"],
+                                            id={"type": "share-btn", "graph": viz_id, "page": page},
+                                            color="outline-info",
+                                            size="sm",
+                                            className="share-graph-button me-2",
+                                        ),
+                                        dbc.Button(
+                                            "About Graph",
+                                            id={"type": "popover-target", "index": f"{page}-{viz_id}"},
+                                            color="outline-secondary",
+                                            size="sm",
+                                            className="about-graph-button",
+                                        ),
+                                    ],
                                     width="auto",
+                                    className="d-flex align-items-center",
                                 ),
                             ],
                             align="center",

--- a/8Knot/pages/index/index_callbacks.py
+++ b/8Knot/pages/index/index_callbacks.py
@@ -885,13 +885,15 @@ def update_pill_color_on_search(search_button_clicks, selected_repos_orgs):
     if not dash.ctx.triggered:
         return dash.no_update
 
-    triggered_id = dash.ctx.triggered_id
+    # Both inputs can change in one update (a shared link sets the selection
+    # AND triggers the search); the search button wins -> pills show blue.
+    triggered_ids = {t["prop_id"].split(".")[0] for t in dash.ctx.triggered}
 
-    if triggered_id == "search-button":
-        # Search button clicked - add 'searching' class to turn pills blue
-        logging.info(f"PILL COLOR: Search clicked - turning pills BLUE")
+    if "search-button" in triggered_ids:
+        # Search performed - add 'searching' class to turn pills blue
+        logging.info(f"PILL COLOR: Search triggered - turning pills BLUE")
         return "searchbar-dropdown searching"
-    if triggered_id == "projects":
+    if "projects" in triggered_ids:
         # Values changed (user selecting) - remove 'searching' class to keep pills red
         logging.info(f"PILL COLOR: Values changed - turning pills RED. Selected: {selected_repos_orgs}")
         return "searchbar-dropdown"

--- a/8Knot/pages/index/index_layout.py
+++ b/8Knot/pages/index/index_layout.py
@@ -30,6 +30,10 @@ from .login_utils import (
     is_login_enabled,
 )
 
+# Share-link modal — own module; must stay out of `create_app_stores()`
+# (mixing share UI into the stores list broke page rendering).
+from .share_components import create_share_modal
+
 # Note: Welcome sections are now imported in pages/landing/landing.py
 
 # Top bar with logos and navigation links
@@ -131,6 +135,7 @@ layout = html.Div(
                 justify="start",
             ),
             navbar_bottom,
+            create_share_modal(),
         ],
         fluid=True,
         className="dbc app-main-container",

--- a/8Knot/pages/index/share_callbacks.py
+++ b/8Knot/pages/index/share_callbacks.py
@@ -1,0 +1,266 @@
+"""
+Callbacks for the shareable URL system.
+
+The whole share is carried in the URL: the searchbar selection + target graph
+are serialized into a versioned gzip+base64url payload under ``?state=``. No
+database — the link is self-contained and survives any cache reset. (A
+DB-backed short-URL layer, ``?s=<id>``, is a planned follow-up PR.)
+
+Integration rules (each one prevents a class of Dash breakage):
+  * Share UI lives in `share_components.create_share_modal()`, NOT in the
+    app stores list.
+  * The load path never writes `repo-choices` directly — it populates
+    `projects` and bumps `search-button.n_clicks`, reusing the existing
+    search pipeline (no `allow_duplicate` races).
+  * Only ONE callback reads `url.search`.
+  * Pattern-matching share-button IDs are callback INPUTS only; every
+    OUTPUT targets a simple string-id modal component.
+"""
+
+from __future__ import annotations
+
+import dash
+from dash import callback, ctx, clientside_callback
+from dash.dependencies import Input, Output, State, ALL
+
+from app import augur
+import cache_manager.url_state as url_state
+from pages.utils import url_utils
+from pages.utils import graph_registry
+from models import SearchItem
+
+
+# -----------------------------------------------------------------------------
+# Helpers (pure orchestration — no Dash coupling)
+# -----------------------------------------------------------------------------
+
+
+def _split_selection(selection: list[str] | None) -> tuple[list[int], list[str]]:
+    """Split a searchbar selection into ``(repo_ids, org_names)``.
+
+    Repos are numeric values, orgs are not (see ``SearchItem.from_id``).
+    Keeping orgs separate lets a shared link restore the single org pill —
+    not its expanded repos — and re-resolve the org's membership on load.
+    """
+    repo_ids, org_names = [], []
+    for v in selection or []:
+        if SearchItem.from_id(v) == SearchItem.REPO:
+            repo_ids.append(int(v))
+        else:
+            org_names.append(v)
+    return repo_ids, org_names
+
+
+def _build_share_url(selection: list[str], pathname: str, href: str, page: str | None, graph_id: str | None) -> str:
+    """Encode the selection into a self-contained share URL.
+
+    The URL fragment must be the card's real DOM id, ``f"{page}-{viz_id}"``
+    (see ``VisualizationAIO``) — the bare viz_id matches no element.
+    """
+    repo_ids, org_names = _split_selection(selection)
+    base_url = url_utils.extract_base_url(href)
+    encoded = url_state.encode_state(
+        repo_ids=repo_ids,
+        org_names=org_names,
+        pathname=pathname,
+        graph_id=graph_id,
+    )
+    anchor = f"{page}-{graph_id}" if (page and graph_id) else None
+    return url_utils.compose_share_url(base_url, encoded, pathname, anchor)
+
+
+def _resolve_selection(repo_ids: list[int], org_names: list[str]) -> tuple[list[dict], list[str], list[int | str]]:
+    """Rebuild searchbar ``(options, values, missing)`` from a decoded payload.
+
+    Each present item needs a matching ``{value, label}`` option because
+    dmc.MultiSelect drops values absent from its ``data``. Items unknown to
+    this instance go to ``missing`` ("load remaining + warn" behavior).
+    """
+    options, values, missing = [], [], []
+
+    for rid in repo_ids:
+        git_url = augur.repo_id_to_git(rid)
+        if git_url:
+            label = git_url[8:] if git_url.startswith("https://") else git_url
+            options.append({"value": str(rid), "label": label})
+            values.append(str(rid))
+        else:
+            missing.append(rid)
+
+    for org in org_names:
+        if augur.is_org(org):
+            options.append({"value": org, "label": org})
+            values.append(org)
+        else:
+            missing.append(org)
+
+    return options, values, missing
+
+
+# -----------------------------------------------------------------------------
+# Callbacks
+# -----------------------------------------------------------------------------
+
+
+@callback(
+    Output("share-modal", "is_open"),
+    Output("share-url-display", "value"),
+    Output("share-warning-text", "children"),
+    Output("share-status-message", "children"),
+    Input({"type": "share-btn", "graph": ALL, "page": ALL}, "n_clicks"),
+    Input("share-modal-close", "n_clicks"),
+    State("projects", "value"),
+    State("url", "pathname"),
+    State("url", "href"),
+    prevent_initial_call=True,
+)
+def manage_share_modal(share_clicks, close_clicks, selection, pathname, href):
+    """Open the share modal with a generated link, or close it.
+
+    Shares the searchbar *selection* (not the resolved ``repo-choices``) so an
+    org stays an org. The clicked graph comes from ``ctx.triggered_id``.
+    """
+    triggered = ctx.triggered_id
+
+    if triggered == "share-modal-close":
+        return False, "", "", ""
+
+    # Pattern inputs can fire with all-None on layout changes; ignore those.
+    if not isinstance(triggered, dict) or not any(c for c in (share_clicks or []) if c):
+        raise dash.exceptions.PreventUpdate
+
+    if not selection:
+        return True, "", "Run a search (select repositories) before sharing.", ""
+
+    url = _build_share_url(selection, pathname, href, triggered.get("page"), triggered.get("graph"))
+    return True, url, "", ""
+
+
+# Clipboard copy runs client-side (dcc.Clipboard has render quirks). Returning
+# the writeText promise reports the true outcome instead of assuming success;
+# navigator.clipboard is undefined on insecure (HTTP) contexts.
+clientside_callback(
+    """
+    function(n_clicks, url) {
+        if (!n_clicks || !url) { return window.dash_clientside.no_update; }
+        var fallback = "Copy failed — press Ctrl/Cmd+C to copy the selected link.";
+        if (!navigator.clipboard) { return fallback; }
+        return navigator.clipboard.writeText(url)
+            .then(function () { return "Link copied to clipboard!"; })
+            .catch(function () { return fallback; });
+    }
+    """,
+    Output("share-status-message", "children", allow_duplicate=True),
+    Input("share-copy-button", "n_clicks"),
+    State("share-url-display", "value"),
+    prevent_initial_call=True,
+)
+
+
+@callback(
+    Output("share-loaded-state", "data"),
+    Output("share-load-alert", "is_open"),
+    Output("share-load-alert", "children"),
+    Input("url", "search"),
+    prevent_initial_call=False,
+)
+def handle_share_url(search):
+    """Resolve a ``?state=`` URL into a payload for the load pipeline.
+
+    The only callback reading ``url.search``; it writes only to its own store
+    and alert, so it is safe to run alongside Dash's page routing on load.
+    """
+    raw_state = url_utils.extract_url_params(search).get("state")
+    if not raw_state:
+        raise dash.exceptions.PreventUpdate  # normal navigation, no share params
+
+    state = url_state.decode_state(raw_state)
+    if state is None:
+        return None, True, "This shared link is in an outdated or invalid format."
+
+    is_valid, _ = graph_registry.validate_target(state.get("pathname"), state.get("graph_id"))
+    if not is_valid:
+        return None, True, "The graph referenced by this link no longer exists."
+
+    repo_ids = state.get("repo_ids", [])
+    org_names = state.get("org_names", [])
+    options, values, missing = _resolve_selection(repo_ids, org_names)
+
+    if not values:
+        return None, True, "None of the repositories/organizations in this link are available on this instance."
+
+    payload = {"options": options, "values": values}
+
+    if missing:
+        total = len(repo_ids) + len(org_names)
+        msg = f"Loaded {len(values)} of {total} selections. {len(missing)} are no longer available on this instance."
+        return payload, True, msg
+
+    return payload, False, ""
+
+
+@callback(
+    Output("projects", "data", allow_duplicate=True),
+    Output("projects", "value"),
+    Output("search-button", "n_clicks"),
+    Input("share-loaded-state", "data"),
+    State("search-button", "n_clicks"),
+    prevent_initial_call=True,
+)
+def apply_share_state(loaded, current_clicks):
+    """Feed a loaded share payload into the existing search pipeline.
+
+    Sets the searchbar selection and bumps ``search-button.n_clicks`` so
+    ``multiselect_values_to_repo_ids`` populates ``repo-choices`` exactly as a
+    manual search would. ``projects.data`` needs ``allow_duplicate=True``; its
+    base writer fires on a disjoint trigger (``searchValue``), so no race.
+    """
+    if not loaded or not loaded.get("values"):
+        raise dash.exceptions.PreventUpdate
+
+    return loaded["options"], loaded["values"], (current_clicks or 0) + 1
+
+
+# Scroll the shared graph into view. The page is client-side rendered, so the
+# native hash scroll fires before the target exists; then graphs above it load
+# and reflow the page. So: poll until the card exists, re-scroll at growing
+# delays through the reflow, and stop as soon as the user scrolls themselves.
+# Keyed on url.hash, so sidebar "#graph" anchors get working scroll too.
+clientside_callback(
+    """
+    function(hash_, _loaded) {
+        if (!hash_) { return window.dash_clientside.no_update; }
+        var id;
+        try { id = decodeURIComponent(hash_.replace(/^#/, '')); }
+        catch (e) { return window.dash_clientside.no_update; }
+        if (!id) { return window.dash_clientside.no_update; }
+        var cancelled = false;
+        function onUserScroll() { cancelled = true; }
+        function scrollToTarget() {
+            if (cancelled) { return true; }
+            var el = document.getElementById(id);
+            if (!el) { return false; }
+            el.scrollIntoView({behavior: 'smooth', block: 'center'});
+            return true;
+        }
+        var tries = 0;
+        (function findThenScroll() {
+            if (cancelled) { return; }
+            if (scrollToTarget()) {
+                window.addEventListener('wheel', onUserScroll, {passive: true, once: true});
+                window.addEventListener('touchmove', onUserScroll, {passive: true, once: true});
+                // re-scroll through ~5.5s of async graph-load reflow
+                [400, 1000, 2000, 3500, 5500].forEach(function(d) { setTimeout(scrollToTarget, d); });
+                return;
+            }
+            // poll up to ~5s for the client-side-rendered card to appear
+            if (tries++ < 20) { setTimeout(findThenScroll, 250); }
+        })();
+        return window.dash_clientside.no_update;
+    }
+    """,
+    Output("share-scroll-dummy", "data"),
+    Input("url", "hash"),
+    Input("share-loaded-state", "data"),
+    prevent_initial_call=False,
+)

--- a/8Knot/pages/index/share_components.py
+++ b/8Knot/pages/index/share_components.py
@@ -1,0 +1,85 @@
+"""
+Share-link UI: the modal and its supporting stores/alert.
+
+Layout only — callbacks live in `share_callbacks.py`. Kept SEPARATE from
+`index_components.py` on purpose: mixing share components into the app-stores
+list broke Dash's page rendering in earlier attempts (Toasts/Clipboards are
+not inert stores). Everything is wrapped in one `html.Div` so the layout file
+adds a single child, as a sibling of the existing layout — never inside
+`create_app_stores()`.
+"""
+
+from dash import html, dcc
+import dash_bootstrap_components as dbc
+
+
+def create_share_modal() -> html.Div:
+    """Return the share modal + state stores, to be appended to the main container."""
+    return html.Div(
+        id="share-system-container",
+        children=[
+            # Channel for URL-loaded share payloads; feeds the existing
+            # search flow instead of writing `repo-choices` directly.
+            dcc.Store(id="share-loaded-state", data=None),
+            # No-op output target for the clientside scroll-to-anchor callback.
+            dcc.Store(id="share-scroll-dummy", data=None),
+            # Feedback when a shared link fails to load (invalid/removed).
+            dbc.Alert(
+                "",
+                id="share-load-alert",
+                is_open=False,
+                dismissable=True,
+                color="warning",
+                className="share-load-alert",
+            ),
+            dbc.Modal(
+                id="share-modal",
+                is_open=False,
+                size="lg",
+                children=[
+                    dbc.ModalHeader(dbc.ModalTitle("Share this graph")),
+                    dbc.ModalBody(
+                        [
+                            html.P(
+                                "Copy the link below to share this exact view "
+                                "(repositories + graph) with someone else.",
+                                className="mb-2",
+                            ),
+                            dbc.InputGroup(
+                                [
+                                    dbc.Input(
+                                        id="share-url-display",
+                                        type="text",
+                                        readonly=True,
+                                        value="",
+                                    ),
+                                    dbc.Button(
+                                        [html.I(className="fas fa-copy me-1"), "Copy"],
+                                        id="share-copy-button",
+                                        color="primary",
+                                        n_clicks=0,
+                                    ),
+                                ]
+                            ),
+                            html.Div(
+                                id="share-status-message",
+                                className="mt-2 text-success",
+                            ),
+                            html.Div(
+                                id="share-warning-text",
+                                className="mt-2 text-warning",
+                            ),
+                        ]
+                    ),
+                    dbc.ModalFooter(
+                        dbc.Button(
+                            "Close",
+                            id="share-modal-close",
+                            color="secondary",
+                            n_clicks=0,
+                        )
+                    ),
+                ],
+            ),
+        ],
+    )

--- a/8Knot/pages/utils/graph_registry.py
+++ b/8Knot/pages/utils/graph_registry.py
@@ -1,0 +1,86 @@
+"""
+Registry of valid (pathname, graph_id) share targets, plus validation.
+
+Domain knowledge (which graphs exist on which pages), kept apart from the pure
+string helpers in ``url_utils.py``. Graph IDs are the real ``VIZ_ID`` values
+the share buttons emit — NOT the sidebar anchor fragments, a different
+identifier space. Single source of truth for share-link validation; a drift
+test re-deriving it from the page layouts arrives in the follow-up test PR.
+"""
+
+from __future__ import annotations
+
+VALID_GRAPH_REGISTRY: dict[str, list[str]] = {
+    "/repo_overview": [
+        "code-languages",
+        "ossf-scorecard",
+        "package-version",
+        "repo-general-info",
+    ],
+    "/contributions": [
+        "cntrib-pr-assignment",
+        "cntrib_issue-assignment",
+        "commits-over-time",
+        "issue-staleness",
+        "issue_assignment",
+        "issues-over-time",
+        "pr-first-response",
+        "pr-review-response",
+        "pr-staleness",
+        "pr_assignment",
+        "prs-over-time",
+        "self-merge",
+    ],
+    "/contributors/behavior": [
+        "active-drifting-contributors",
+        "contrib-drive-repeat",
+        "contrib-types-over-time",
+        "first-time-contribution",
+        "new-contributor",
+    ],
+    "/contributors/contribution_types": [
+        "contrib-activity-cycle",
+        "contrib-importance-pie",
+        "contribs-by-action",
+        "lottery-factor-over-time",
+    ],
+    "/chaoss": [
+        "contrib-importance-pie",
+        "project-velocity",
+    ],
+    "/affiliation": [
+        "commit-domains",
+        "gh-org-affiliation",
+        "org-core-contributors",
+        "organization-associated-activity",
+        "unique-domains",
+    ],
+    "/codebase": [
+        "cntrb-file-heatmap",
+        "contribution-file-heatmap",
+        "reviewer-file-heatmap",
+    ],
+}
+
+# Maps a removed/renamed (pathname, graph_id) to its replacement (or None when
+# dropped with no successor). This is the migration seam: when a graph moves or
+# is retired, add an entry here so old shared links resolve gracefully instead
+# of dead-ending.
+DEPRECATED_GRAPH_REGISTRY: dict[tuple, tuple | None] = {}
+
+
+def validate_target(pathname: str, graph_id: str | None) -> tuple[bool, tuple | None]:
+    """Return ``(is_valid, redirect)`` for a shared link target.
+
+    A target is valid when its pathname is a known viz page AND its graph_id is
+    either absent (no specific graph) or one this page actually renders. An
+    unknown graph on a known page is treated as removed, so it can fall through
+    to the deprecation registry (and otherwise reads as "no longer exists").
+    """
+    graphs = VALID_GRAPH_REGISTRY.get(pathname)
+    if graphs is not None and (graph_id is None or graph_id in graphs):
+        return True, None
+    deprecated = DEPRECATED_GRAPH_REGISTRY.get((pathname, graph_id))
+    if deprecated is not None:
+        return False, deprecated
+    return False, None

--- a/8Knot/pages/utils/url_utils.py
+++ b/8Knot/pages/utils/url_utils.py
@@ -1,0 +1,39 @@
+"""
+Pure URL helpers for the shareable-link system.
+
+String composition and parsing only — no Dash coupling and no knowledge of
+which graphs exist (that domain logic lives in ``graph_registry.py``).
+"""
+
+from __future__ import annotations
+
+from urllib.parse import parse_qs, urlsplit
+
+
+def compose_share_url(base: str, encoded_state: str, pathname: str, anchor: str | None) -> str:
+    """Assemble ``<base><pathname>?state=<blob>[#anchor]``.
+
+    ``anchor`` is the target graph card's DOM id (``f"{page}-{viz_id}"``) so the
+    browser-side scroll handler can land on the exact graph.
+    """
+    frag = f"#{anchor}" if anchor else ""
+    return f"{base.rstrip('/')}{pathname}?state={encoded_state}{frag}"
+
+
+def extract_base_url(href: str) -> str:
+    """Return ``scheme://netloc`` from a full href, robust to path collisions.
+
+    Using urlsplit (rather than string slicing on the pathname) means a
+    hostname that happens to contain the pathname can't corrupt the result.
+    """
+    parts = urlsplit(href or "")
+    return f"{parts.scheme}://{parts.netloc}"
+
+
+def extract_url_params(search: str) -> dict:
+    if not search:
+        return {}
+    params = parse_qs(search.lstrip("?"))
+    return {
+        "state": (params.get("state") or [None])[0],
+    }


### PR DESCRIPTION
This PR implements a shareable URL button, where the user can share the url for each graph view on the app. Previous anchor was implemented using only the page view, instead of the right anchor id, which is set as viz + page_view id. 

 

### Pull Request Change Description
<!-- Please give a thorough descriptions of the intended changes made by this PR -->

### Generative AI disclosure
<!-- To learn more about our Generative AI policy and required disclosures, see the `CONTRIBUTING.md` file -->

Please select one option:

- [ ] This contribution was NOT assisted or created by Generative AI tools.
- [x] This contribution was assisted or created by Generative AI tools.


If AI tools were used, please provide details below:
    - What tools were used? <!-- gemini / chatgpt / claude .etc --> Claude Fable 5
    - How were these tools used? <!-- initial draft of the code / code review / writing tests .etc --> Draft, review.
    - Did you review these outputs before submitting this PR? <!-- No / Yes and I made these fixes... --> Yes, reviewed and tested.
